### PR TITLE
Bump to 0.2.1 (change repo url)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,10 +1,10 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.2.0"
+version = "0.2.1"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
-repository = "https://github.com/zed-industries/zed"
+repository = "https://github.com/zed-extensions/ruby"
 
 [language_servers.solargraph]
 name = "Solargraph"


### PR DESCRIPTION
- Change the repo URL to https://github.com/zed-extensions/ruby
- Bump the version to 0.2.1

See also:
- https://github.com/zed-industries/zed/pull/19098