### PR TITLE
Recognize `Thorfile` as a Ruby file

### DIFF
--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -25,6 +25,7 @@ path_suffixes = [
     "Brewfile",
     "Vagrantfile",
     "Puppetfile",
+    "Thorfile",
 ]
 first_line_pattern = '^#!.*\bruby\b'
 line_comments = ["# "]


### PR DESCRIPTION
Hi, this pull request adds support for highlighting `Thorfile` files which are Ruby files https://github.com/rails/thor/wiki/Getting-Started#file-names

Here are before&after screenshots.

|before|after|
|-------|-----|
| ![CleanShot 2024-10-22 at 16 35 31@2x](https://github.com/user-attachments/assets/c2bbdbff-fd3b-4dec-807d-f67f22546463) | ![CleanShot 2024-10-22 at 16 39 23@2x](https://github.com/user-attachments/assets/0599eefb-3197-43b5-9215-ccf548ba8e50)|

Thanks.