### PR TITLE
Add label details to ruby-lsp completions

### DIFF
--- a/src/language_servers/ruby_lsp.rs
+++ b/src/language_servers/ruby_lsp.rs
@@ -76,11 +76,22 @@ impl RubyLsp {
         };
 
         let len = completion.label.len();
-        let name_span = CodeLabelSpan::literal(completion.label, Some(highlight_name.to_string()));
+        let mut spans = vec![CodeLabelSpan::literal(
+            completion.label,
+            Some(highlight_name.to_string()),
+        )];
+
+        if let Some(detail) = completion
+            .label_details
+            .and_then(|label_details| label_details.detail)
+        {
+            spans.push(CodeLabelSpan::literal(" ", None));
+            spans.push(CodeLabelSpan::literal(detail, None));
+        }
 
         Some(CodeLabel {
             code: Default::default(),
-            spans: vec![name_span],
+            spans,
             filter_range: (0..len).into(),
         })
     }


### PR DESCRIPTION
The `ruby-lsp` language server sends additional
completion details via `completion.label_details` field:

```json
{
  "label": "eql?",
  "labelDetails": { "detail": "(other)", "description": "kernel.rbs" }
}
```

Starting from `zed_extension_api` v0.2.0 we can use this field
to display additional completion details.

![CleanShot 2024-11-15 at 17 38 21@2x](https://github.com/user-attachments/assets/c4e46651-c8ce-4d7b-b10a-1c368b9d1291)

**NOTE:** This PR depends on https://github.com/zed-extensions/ruby/pull/12
