### PR TITLE
Bump to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.2.2"
+version = "0.2.3"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"


### PR DESCRIPTION
Bump version to 0.2.3.

## Changelog

- Update `config.toml` to include additional Ruby-related files (https://github.com/zed-extensions/ruby/pull/5)
- Upgrade `zed_extension_api` to `v0.2.0` (https://github.com/zed-extensions/ruby/pull/12)
- Add label details to `ruby-lsp` completions (https://github.com/zed-extensions/ruby/pull/13)

https://github.com/zed-extensions/ruby/compare/v0.2.2...v0.2.3