### PR TITLE
Use bundler for `solargraph` and `rubocop`

### DIFF
--- a/src/language_servers/rubocop.rs
+++ b/src/language_servers/rubocop.rs
@@ -32,10 +32,10 @@ impl Rubocop {
 
     fn language_server_binary(
         &self,
-        _language_server_id: &LanguageServerId,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<RubocopBinary> {
-        let lsp_settings = LspSettings::for_worktree("rubocop", worktree)?;
+        let lsp_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
 
         let binary_settings = lsp_settings.binary;
         let binary_args = binary_settings
@@ -53,7 +53,7 @@ impl Rubocop {
             .settings
             .as_ref()
             .and_then(|settings| settings["use_bundler"].as_bool())
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         if use_bundler {
             worktree

--- a/src/language_servers/solargraph.rs
+++ b/src/language_servers/solargraph.rs
@@ -55,7 +55,7 @@ impl Solargraph {
             .settings
             .as_ref()
             .and_then(|settings| settings["use_bundler"].as_bool())
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         if use_bundler {
             worktree


### PR DESCRIPTION
That improves the developer experience (DX) when using `solargraph` and 
`rubocop` LSPs. Both LSPs work best when started in the context of Bundler. 

**How does it work currently?** Here is an example with `rubocop`: if 
`rubocop` exists in the PATH, use it. So end users have two options: specify 
the full path to the `rubocop` binary (or to `bundle`) or generate a binstub 
and then add the `<project_dir>/bin` folder to PATH.

This is not optimal because most of the time we want to use and spawn LSPs in 
the context of Bundler to ensure we load the correct gemset. This does not 
fully apply to `ruby-lsp`, which can work without `bundle exec`.

Overall, the new configuration option `use_bundler` is configured as follows:

1. **Solargraph:** Use Bundler by default.
2. **Rubocop:** Use Bundler by default.
3. **Ruby LSP:** Do not use Bundler by default.