### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.2.3"
+version = "0.3.3"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.2.3"
+version = "0.3.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.2.3"
+version = "0.3.3"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"


### PR DESCRIPTION
Closes https://github.com/zed-extensions/ruby/issues/16

Bump version to 0.3.3. This version includes a single breaking change.

## Changelog:

- Use bundler by default when running `solargraph`
- Use bundler by default when running `rubocop`

The new configuration option use_bundler is configured as follows:

**Solargraph:** Use Bundler by default.
**Rubocop:** Use Bundler by default.
**Ruby LSP:** Do not use Bundler by default.