### PR TITLE
Extract common LSPs stuff into `LanguageServer` trait

### DIFF
--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,7 +1,9 @@
+mod language_server;
 mod rubocop;
 mod ruby_lsp;
 mod solargraph;
 
+pub use language_server::LanguageServer;
 pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -1,0 +1,92 @@
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+
+#[derive(Clone, Debug)]
+pub struct LanguageServerBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
+
+pub trait LanguageServer {
+    const SERVER_ID: &str;
+    const EXECUTABLE_NAME: &str;
+
+    fn default_use_bundler() -> bool {
+        true // Default for most LSPs except Ruby LSP
+    }
+
+    fn get_executable_args() -> Vec<String> {
+        Vec::new()
+    }
+
+    fn language_server_binary(
+        &self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<LanguageServerBinary> {
+        let lsp_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
+
+        if let Some(binary_settings) = lsp_settings.binary {
+            if let Some(path) = binary_settings.path {
+                return Ok(LanguageServerBinary {
+                    path,
+                    args: binary_settings.arguments,
+                });
+            }
+        }
+
+        let use_bundler = lsp_settings
+            .settings
+            .as_ref()
+            .and_then(|settings| settings["use_bundler"].as_bool())
+            .unwrap_or(Self::default_use_bundler());
+
+        if use_bundler {
+            worktree
+                .which("bundle")
+                .map(|path| LanguageServerBinary {
+                    path,
+                    args: Some(
+                        [
+                            vec!["exec".to_string(), Self::EXECUTABLE_NAME.to_string()],
+                            Self::get_executable_args(),
+                        ]
+                        .concat(),
+                    ),
+                })
+                .ok_or_else(|| "Unable to find the 'bundle' command.".into())
+        } else {
+            worktree
+                .which(Self::EXECUTABLE_NAME)
+                .map(|path| LanguageServerBinary {
+                    path,
+                    args: Some(Self::get_executable_args()),
+                })
+                .ok_or_else(|| format!("Unable to find the '{}' command.", Self::EXECUTABLE_NAME))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestServer {}
+    impl LanguageServer for TestServer {
+        const SERVER_ID: &'static str = "test-server";
+        const EXECUTABLE_NAME: &'static str = "test-exe";
+
+        fn get_executable_args() -> Vec<String> {
+            vec!["--test-arg".into()]
+        }
+    }
+
+    #[test]
+    fn test_default_use_bundler() {
+        assert!(TestServer::default_use_bundler());
+    }
+
+    #[test]
+    fn test_default_executable_args() {
+        assert!(TestServer::get_executable_args() == vec!["--test-arg"]);
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,12 +1,12 @@
 mod language_servers;
+use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};
 
 use zed::lsp::{Completion, Symbol};
 use zed::settings::LspSettings;
 use zed::{serde_json, CodeLabel, LanguageServerId};
 use zed_extension_api::{self as zed, Result};
 
-use crate::language_servers::{Rubocop, RubyLsp, Solargraph};
-
+#[derive(Default)]
 struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
@@ -15,11 +15,7 @@ struct RubyExtension {
 
 impl zed::Extension for RubyExtension {
     fn new() -> Self {
-        Self {
-            solargraph: None,
-            ruby_lsp: None,
-            rubocop: None,
-        }
+        Self::default()
     }
 
     fn language_server_command(
@@ -28,15 +24,15 @@ impl zed::Extension for RubyExtension {
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
-            Solargraph::LANGUAGE_SERVER_ID => {
+            Solargraph::SERVER_ID => {
                 let solargraph = self.solargraph.get_or_insert_with(Solargraph::new);
                 solargraph.language_server_command(language_server_id, worktree)
             }
-            RubyLsp::LANGUAGE_SERVER_ID => {
+            RubyLsp::SERVER_ID => {
                 let ruby_lsp = self.ruby_lsp.get_or_insert_with(RubyLsp::new);
                 ruby_lsp.language_server_command(language_server_id, worktree)
             }
-            Rubocop::LANGUAGE_SERVER_ID => {
+            Rubocop::SERVER_ID => {
                 let rubocop = self.rubocop.get_or_insert_with(Rubocop::new);
                 rubocop.language_server_command(language_server_id, worktree)
             }
@@ -50,8 +46,8 @@ impl zed::Extension for RubyExtension {
         symbol: Symbol,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
-            Solargraph::LANGUAGE_SERVER_ID => self.solargraph.as_ref()?.label_for_symbol(symbol),
-            RubyLsp::LANGUAGE_SERVER_ID => self.ruby_lsp.as_ref()?.label_for_symbol(symbol),
+            Solargraph::SERVER_ID => self.solargraph.as_ref()?.label_for_symbol(symbol),
+            RubyLsp::SERVER_ID => self.ruby_lsp.as_ref()?.label_for_symbol(symbol),
             _ => None,
         }
     }
@@ -62,10 +58,8 @@ impl zed::Extension for RubyExtension {
         completion: Completion,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
-            Solargraph::LANGUAGE_SERVER_ID => {
-                self.solargraph.as_ref()?.label_for_completion(completion)
-            }
-            RubyLsp::LANGUAGE_SERVER_ID => self.ruby_lsp.as_ref()?.label_for_completion(completion),
+            Solargraph::SERVER_ID => self.solargraph.as_ref()?.label_for_completion(completion),
+            RubyLsp::SERVER_ID => self.ruby_lsp.as_ref()?.label_for_completion(completion),
             _ => None,
         }
     }


### PR DESCRIPTION
Extract common LSPs stuff into `LanguageServer` trait. There is a common piece of code that is repeated across all LSPs. It can be extracted into `LanguageServer` trait to make the code a bit more readable, in my opinion. I also added some basic unit tests.