### PR TITLE
Add `StandardRB` LSP

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -18,6 +18,10 @@ languages = ["Ruby", "ERB"]
 name = "Rubocop"
 languages = ["Ruby"]
 
+[language_servers.standardrb]
+name = "Standardrb"
+languages = ["Ruby"]
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "7dbc1e2d0e2d752577655881f73b4573f3fe85d4"

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -2,8 +2,10 @@ mod language_server;
 mod rubocop;
 mod ruby_lsp;
 mod solargraph;
+mod standard;
 
 pub use language_server::LanguageServer;
 pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;
+pub use standard::*;

--- a/src/language_servers/standard.rs
+++ b/src/language_servers/standard.rs
@@ -1,0 +1,58 @@
+use super::language_server::LanguageServer;
+use zed_extension_api::{self as zed, LanguageServerId, Result};
+
+pub struct Standard {}
+
+impl LanguageServer for Standard {
+    const SERVER_ID: &str = "standardrb";
+    const EXECUTABLE_NAME: &str = "standardrb";
+
+    fn get_executable_args() -> Vec<String> {
+        vec!["--lsp".into()]
+    }
+}
+
+impl Standard {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary = self.language_server_binary(language_server_id, worktree)?;
+
+        Ok(zed::Command {
+            command: binary.path,
+            args: binary.args.unwrap_or(Self::get_executable_args()),
+            env: Default::default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::language_servers::{LanguageServer, Standard};
+
+    #[test]
+    fn test_server_id() {
+        assert_eq!(Standard::SERVER_ID, "standardrb");
+    }
+
+    #[test]
+    fn test_executable_name() {
+        assert_eq!(Standard::EXECUTABLE_NAME, "standardrb");
+    }
+
+    #[test]
+    fn test_executable_args() {
+        assert_eq!(Standard::get_executable_args(), vec!["--lsp"]);
+    }
+
+    #[test]
+    fn test_default_use_bundler() {
+        assert!(Standard::default_use_bundler());
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,5 +1,5 @@
 mod language_servers;
-use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};
+use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph, Standard};
 
 use zed::lsp::{Completion, Symbol};
 use zed::settings::LspSettings;
@@ -11,6 +11,7 @@ struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
     rubocop: Option<Rubocop>,
+    standard: Option<Standard>,
 }
 
 impl zed::Extension for RubyExtension {
@@ -35,6 +36,10 @@ impl zed::Extension for RubyExtension {
             Rubocop::SERVER_ID => {
                 let rubocop = self.rubocop.get_or_insert_with(Rubocop::new);
                 rubocop.language_server_command(language_server_id, worktree)
+            }
+            Standard::SERVER_ID => {
+                let standard = self.standard.get_or_insert_with(Standard::new);
+                standard.language_server_command(language_server_id, worktree)
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }


### PR DESCRIPTION
Add `StandardRB` LSP which is quite popular in the Ruby world - [https://github.com/standardrb/standard](https://github.com/standardrb/standard)

This LSP is based on `rubocop` but it ships with its own binaries and CLI arguments. [Configuring `rubocop` to run the `StandardRB` tool](https://github.com/standardrb/standard?tab=readme-ov-file#running-standards-rules-via-rubocop) on top of it is documented, but it states that this could be removed at any time.