### PR TITLE
Remove .rdoc from the list of Ruby files

### DIFF
--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -16,7 +16,6 @@ path_suffixes = [
     "rxml",
     "builder",
     "gemspec",
-    "rdoc",
     "thor",
     "pryrc",
     "simplecov",


### PR DESCRIPTION
RDoc is a markup language designed to document Ruby code, but it isn't Ruby code itself, so Zed shouldn't set the language to Ruby.
