### PR TITLE
Add back in support for Minitest/RSpec symbols

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -18,3 +18,12 @@
 (module
     "module" @context
     name: (_) @name) @item
+
+; Support Minitest/RSpec symbols
+;
+; Note that `(_)+` is used to capture one more child nodes, meaning it will also include any modifier symbols, like
+; :focus, so that we can easily jump to focused tests
+(call
+    method: (identifier) @run (#any-of? @run "describe" "context" "test" "it")
+    arguments: (argument_list . (_)+) @name
+) @item


### PR DESCRIPTION
This adds back in support for Minitest/RSpec symbols

Previously https://github.com/zed-industries/zed/pull/12052 added this but for some reason the commit is gone now. I've gone ahead and added it back in with some minor improvements, like adding support for symbols like `:focus`. 
![CleanShot 2025-02-07 at 22 16 52@2x](https://github.com/user-attachments/assets/bf08de7a-6c22-4367-a14f-cfb927e3f078)
