### PR TITLE
Add textobjects support

### DIFF
--- a/languages/ruby/textobjects.scm
+++ b/languages/ruby/textobjects.scm
@@ -1,0 +1,22 @@
+; Adapted from https://github.com/helix-editor/helix/blob/master/runtime/queries/ruby/textobjects.scm
+
+; Class and Modules
+(class
+  body: (_)? @class.inside) @class.around
+
+(singleton_class
+  value: (_)
+  (_)+ @class.inside) @class.around
+
+(module
+  body: (_)? @class.inside) @class.around
+
+; Functions and Blocks
+(singleton_method
+  body: (_)? @function.inside) @function.around
+
+(method
+  body: (_)? @function.inside) @function.around
+
+; Comments
+(comment) @comment.inside


### PR DESCRIPTION
Adds `textobjects` support.

# Classes and modules

https://github.com/user-attachments/assets/73881f12-7d23-4cae-9a43-6534c50cafcd

```ruby
# Class and Modules:

# ac - around class
# ic - inside class
class User < ApplicationRecord
  def full_name
    "#{first_name} #{last_name}"
  end
end

# ac - around class
# ic - inside class
class << User
  def find_admin
    where(admin: true).first
  end
end

# ac - around class (module)
# ic - inside class (module)
module Notifiable
  def send_notification
    # Notification logic
  end
end
```


# Functions and blocks

https://github.com/user-attachments/assets/e7ecb4b5-b8fb-4457-8e36-8a8e1dbce9b1



```ruby
# Functions and Blocks:

# af - around function
# if - inside function
def self.active_users
  where(active: true)
end

# af - around function
# if - inside function
def calculate_total
  items.sum(&:price)
end
```


