### PR TITLE
Remove default `tasks.json`

### DIFF
--- a/languages/ruby/tasks.json
+++ b/languages/ruby/tasks.json
@@ -1,7 +1,0 @@
-[
-  {
-    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "echo 'To run tests, configure tasks in your \".zed/tasks.json\" file as described in the Ruby extension documentation.'",
-    "tags": ["ruby-test"]
-  }
-]


### PR DESCRIPTION
Remove the placeholder `tasks.json` file
that contained a dummy test task.
This task would appear in users' task lists
despite not being functional, creating confusion.



![image](https://github.com/user-attachments/assets/69faf9c0-462d-408e-bcc9-156d73dd08a8)

Closes https://github.com/zed-extensions/ruby/issues/35