### PR TITLE
Remove `else` from outdent triggers

### DIFF
--- a/languages/ruby/indents.scm
+++ b/languages/ruby/indents.scm
@@ -5,13 +5,15 @@
 (singleton_method "end" @end) @indent
 (do_block "end" @end) @indent
 
-(then) @indent
-(call) @indent
+[
+  (then)
+  (call)
+] @indent
 
-(ensure) @outdent
-(rescue) @outdent
-(else) @outdent
-
+[
+  (ensure)
+  (rescue)
+] @outdent
 
 (_ "[" "]" @end) @indent
 (_ "{" "}" @end) @indent


### PR DESCRIPTION
Closes https://github.com/zed-extensions/ruby/issues/39

Remove `else` from outdent triggers to indent the `else` keyword properly.

The `else` outdent is used for use cases with `begin..rescue..else..end`. Consider the following code block:

```ruby
def test
  begin
    a
  rescue
    puts "Something went wrong!"
else
|#<= cursor position
end
```


https://github.com/user-attachments/assets/27c18735-7aba-4662-b045-2bfd9df0ae21



Currently the `else` keyword is indented incorrectly but removing the `else` keyword from the indents triggers turns the same block into this:

```ruby
def test
  begin
    a
  rescue
    puts "Something went wrong!"
  else
  |#<= cursor position
end
```


https://github.com/user-attachments/assets/6c09dcc4-90b6-4268-9648-b224becbd402

