### PR TITLE
Add Standardrb language server support for Ruby

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -18,6 +18,10 @@ languages = ["Ruby", "ERB"]
 name = "Rubocop"
 languages = ["Ruby"]
 
+[language_servers.standardrb]
+name = "Standardrb"
+languages = ["Ruby"]
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "71bd32fb7607035768799732addba884a37a6210"

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -2,8 +2,10 @@ mod language_server;
 mod rubocop;
 mod ruby_lsp;
 mod solargraph;
+mod standardrb;
 
 pub use language_server::LanguageServer;
 pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;
+pub use standardrb::*;

--- a/src/language_servers/standardrb.rs
+++ b/src/language_servers/standardrb.rs
@@ -1,0 +1,43 @@
+use super::LanguageServer;
+
+pub struct Standardrb {}
+
+impl LanguageServer for Standardrb {
+    const SERVER_ID: &str = "standardrb";
+    const EXECUTABLE_NAME: &str = "standardrb";
+
+    fn get_executable_args() -> Vec<String> {
+        vec!["--lsp".to_string()]
+    }
+}
+
+impl Standardrb {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::language_servers::{LanguageServer, Standardrb};
+
+    #[test]
+    fn test_server_id() {
+        assert_eq!(Standardrb::SERVER_ID, "standardrb");
+    }
+
+    #[test]
+    fn test_executable_name() {
+        assert_eq!(Standardrb::EXECUTABLE_NAME, "standardrb");
+    }
+
+    #[test]
+    fn test_executable_args() {
+        assert_eq!(Standardrb::get_executable_args(), vec!["--lsp"]);
+    }
+
+    #[test]
+    fn test_default_use_bundler() {
+        assert!(Standardrb::default_use_bundler());
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,5 +1,5 @@
 mod language_servers;
-use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};
+use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph, Standardrb};
 
 use zed::lsp::{Completion, Symbol};
 use zed::settings::LspSettings;
@@ -11,6 +11,7 @@ struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
     rubocop: Option<Rubocop>,
+    standardrb: Option<Standardrb>,
 }
 
 impl zed::Extension for RubyExtension {
@@ -35,6 +36,10 @@ impl zed::Extension for RubyExtension {
             Rubocop::SERVER_ID => {
                 let rubocop = self.rubocop.get_or_insert_with(Rubocop::new);
                 rubocop.language_server_command(language_server_id, worktree)
+            }
+            Standardrb::SERVER_ID => {
+                let standardrb = self.standardrb.get_or_insert_with(Standardrb::new);
+                standardrb.language_server_command(language_server_id, worktree)
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }


### PR DESCRIPTION
Until pull diagnostics are implemented, [standardrb](https://github.com/standardrb/standard) can be run in lsp mode to provide diagnostics and linting. I adapted @himynameisjonas extension [himynameisjonas/zed-standardrb](https://github.com/himynameisjonas/zed-standardrb] to be included as an out-of-the box LSP for Ruby.