### PR TITLE
Use new process API for starting language servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +456,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +826,7 @@ dependencies = [
 name = "zed_ruby"
 version = "0.5.6"
 dependencies = [
+ "regex",
  "zed_extension_api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ path = "src/ruby.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+regex = "1.11.1"
 zed_extension_api = "0.5.0"

--- a/extension.toml
+++ b/extension.toml
@@ -33,12 +33,12 @@ commit = "de893b166476205b09e79cd3689f95831269579a"
 [[capabilities]]
 kind = "process:exec"
 command = "gem"
-args = ["install", "--no-user-install", "--no-format-executable", "--no-document", "*", "--norc"]
+args = ["install", "--norc", "--no-user-install", "--no-format-executable", "--no-document", "*"]
 
 [[capabilities]]
 kind = "process:exec"
 command = "gem"
-args = ["list", "--exact", "*", "--norc"]
+args = ["list", "--norc", "--exact", "*"]
 
 [[capabilities]]
 kind = "process:exec"
@@ -49,3 +49,8 @@ args = ["info", "--version", "*"]
 kind = "process:exec"
 command = "gem"
 args = ["outdated", "--norc"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "gem"
+args = ["update", "--norc", "*"]

--- a/extension.toml
+++ b/extension.toml
@@ -29,3 +29,23 @@ commit = "332262529bc51abf5746317b2255ccc2fff778f8"
 [grammars.rbs]
 repository = "https://github.com/joker1007/tree-sitter-rbs"
 commit = "de893b166476205b09e79cd3689f95831269579a"
+
+[[capabilities]]
+kind = "process:exec"
+command = "gem"
+args = ["install", "--no-user-install", "--no-format-executable", "--no-document", "--env-shebang", "*"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "gem"
+args = ["list", "--exact", "*"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "bundle"
+args = ["info", "*"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "gem"
+args = ["outdated", "--norc"]

--- a/extension.toml
+++ b/extension.toml
@@ -33,17 +33,17 @@ commit = "de893b166476205b09e79cd3689f95831269579a"
 [[capabilities]]
 kind = "process:exec"
 command = "gem"
-args = ["install", "--no-user-install", "--no-format-executable", "--no-document", "--env-shebang", "*"]
+args = ["install", "--no-user-install", "--no-format-executable", "--no-document", "*", "--norc"]
 
 [[capabilities]]
 kind = "process:exec"
 command = "gem"
-args = ["list", "--exact", "*"]
+args = ["list", "--exact", "*", "--norc"]
 
 [[capabilities]]
 kind = "process:exec"
 command = "bundle"
-args = ["info", "*"]
+args = ["info", "--version", "*"]
 
 [[capabilities]]
 kind = "process:exec"

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use zed_extension_api::{Command, Result};
 
 /// A simple wrapper around the `bundle` command.
@@ -13,23 +12,22 @@ impl Bundler {
     }
 
     pub fn installed_gem_version(&self, name: &str) -> Result<String> {
-        let args = vec!["info", "--version", name];
+        let args = vec!["--version".into(), name.into()];
 
-        self.execute_gem_command(args)
-            .map_err(|e| format!("Failed to get version for gem '{}': {}", name, e))
+        self.execute_bundle_command("info".into(), args)
     }
 
-    fn execute_gem_command(&self, args: Vec<&str>) -> Result<String> {
+    fn execute_bundle_command(&self, cmd: String, args: Vec<String>) -> Result<String> {
         let bundle_gemfile_path = Path::new(&self.working_dir).join("Gemfile");
         let bundle_gemfile = bundle_gemfile_path
             .to_str()
             .ok_or("Invalid path to Gemfile")?;
 
         Command::new("bundle")
+            .arg(cmd)
             .args(args)
             .env("BUNDLE_GEMFILE", bundle_gemfile)
             .output()
-            .map_err(|e| format!("Failed to execute 'bundle' command: {}", e))
             .and_then(|output| match output.status {
                 Some(0) => Ok(String::from_utf8_lossy(&output.stdout).to_string()),
                 Some(status) => {

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+use zed_extension_api::{Command, Result};
+
+/// A simple wrapper around the `bundle` command.
+pub struct Bundler {
+    pub working_dir: String,
+}
+
+impl Bundler {
+    pub fn new(working_dir: String) -> Self {
+        Bundler { working_dir }
+    }
+
+    pub fn installed_gem_version(&self, name: &str) -> Result<String> {
+        let args = vec!["info", "--version", name];
+
+        self.execute_gem_command(args)
+            .map_err(|e| format!("Failed to get version for gem '{}': {}", name, e))
+    }
+
+    fn execute_gem_command(&self, args: Vec<&str>) -> Result<String> {
+        let bundle_gemfile_path = Path::new(&self.working_dir).join("Gemfile");
+        let bundle_gemfile = bundle_gemfile_path
+            .to_str()
+            .ok_or("Invalid path to Gemfile")?;
+
+        Command::new("bundle")
+            .args(args)
+            .env("BUNDLE_GEMFILE", bundle_gemfile)
+            .output()
+            .map_err(|e| format!("Failed to execute 'bundle' command: {}", e))
+            .and_then(|output| match output.status {
+                Some(0) => Ok(String::from_utf8_lossy(&output.stdout).to_string()),
+                Some(status) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(format!(
+                        "'bundle' command failed (status: {})\nError: {}",
+                        status, stderr
+                    ))
+                }
+                None => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(format!("Failed to execute 'bundle' command: {}", stderr))
+                }
+            })
+    }
+}

--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -1,0 +1,104 @@
+use regex::Regex;
+use zed_extension_api::{Command, Result};
+
+pub struct Gemset {
+    pub gem_home: String,
+}
+
+impl Gemset {
+    pub fn new(gem_home: String) -> Self {
+        Self { gem_home }
+    }
+
+    pub fn install_gem(&self, name: String) -> Result<()> {
+        let args = vec![
+            "install",
+            "--no-user-install", // Do not install gems in user's home directory
+            "--no-format-executable", // Do not make installed executable names match Ruby
+            "--no-document",     // Do not generate documentation
+            "--env-shebang",
+            &name,
+        ];
+
+        self.execute_gem_command(args)
+            .map_err(|e| format!("Failed to install gem '{}': {}", name, e))?;
+
+        Ok(())
+    }
+
+    pub fn update_gem(&self, name: String) -> Result<()> {
+        let args = vec!["update", &name];
+        let a = false;
+
+        self.execute_gem_command(args)
+            .map_err(|e| format!("Failed to update gem '{}': {}", name, e))?;
+
+        Ok(())
+    }
+
+    pub fn installed_gem_version(&self, name: String) -> Result<Option<String>> {
+        // Example output from `gem list`:
+        /*
+            *** LOCAL GEMS ***
+            abbrev (0.1.2)
+            prism (default: 1.2.0)
+            test-unit (3.6.7)
+        */
+        let re = Regex::new(r"^(\S+) \((\S+)\)$")
+            .map_err(|e| format!("Failed to compile regex: {}", e))?;
+
+        let args = vec!["list", "--exact", &name];
+        let output = self
+            .execute_gem_command(args)
+            .map_err(|e| format!("Failed to get version for gem '{}': {}", name, e))?;
+
+        for line in output.lines() {
+            let captures = match re.captures(line) {
+                Some(c) => c,
+                None => continue,
+            };
+
+            let gem_package = captures.get(1).map(|m| m.as_str());
+            let version = captures.get(2).map(|m| m.as_str());
+
+            if gem_package == Some(&name) {
+                return Ok(version.map(|v| v.to_owned()));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn is_outdated_gem(&self, name: String) -> Result<bool> {
+        let args = vec!["outdated", "--norc"];
+        let output = self
+            .execute_gem_command(args)
+            .map_err(|e| format!("Failed to check if gem is outdated: {}", e))?;
+
+        Ok(output
+            .lines()
+            .any(|line| line.split_whitespace().next().map_or(false, |n| n == name)))
+    }
+
+    fn execute_gem_command(&self, args: Vec<&str>) -> Result<String> {
+        Command::new("gem")
+            .env("GEM_HOME", &self.gem_home)
+            .args(args)
+            .output()
+            .map_err(|e| format!("Failed to execute gem command: {}", e))
+            .and_then(|output| match output.status {
+                Some(0) => Ok(String::from_utf8_lossy(&output.stdout).to_string()),
+                Some(status) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(format!(
+                        "Gem command failed (status: {})\nError: {}",
+                        status, stderr
+                    ))
+                }
+                None => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                    Err(format!("Failed to execute gem command: {}", stderr))
+                }
+            })
+    }
+}

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -1,4 +1,6 @@
-use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+use zed_extension_api::{
+    self as zed, process::Command, settings::LspSettings, LanguageServerId, Result,
+};
 
 #[derive(Clone, Debug)]
 pub struct LanguageServerBinary {
@@ -9,6 +11,7 @@ pub struct LanguageServerBinary {
 pub trait LanguageServer {
     const SERVER_ID: &str;
     const EXECUTABLE_NAME: &str;
+    const GEM_NAME: &str;
 
     fn default_use_bundler() -> bool {
         true // Default for most LSPs except Ruby LSP
@@ -37,6 +40,12 @@ pub trait LanguageServer {
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<LanguageServerBinary> {
+        let output = Command::new("ls").output()?;
+
+        dbg!(&output.status);
+        dbg!(String::from_utf8_lossy(&output.stdout).to_string());
+        dbg!(String::from_utf8_lossy(&output.stderr).to_string());
+
         let lsp_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
 
         if let Some(binary_settings) = lsp_settings.binary {
@@ -88,6 +97,7 @@ mod tests {
     impl LanguageServer for TestServer {
         const SERVER_ID: &'static str = "test-server";
         const EXECUTABLE_NAME: &'static str = "test-exe";
+        const GEM_NAME: &'static str = "test";
 
         fn get_executable_args() -> Vec<String> {
             vec!["--test-arg".into()]

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -62,31 +62,30 @@ pub trait LanguageServer {
             .as_ref()
             .and_then(|settings| settings["use_bundler"].as_bool())
             .unwrap_or(true);
-        let bundler = Bundler::new(worktree.root_path());
 
         if !use_bundler {
-            // User opted for not using 'bundler`. Fallback to the extension' gem.
-            self.extension_gemset_language_server_binary(language_server_id)
-        } else {
-            match bundler.installed_gem_version(Self::GEM_NAME) {
-                Ok(_version) => {
-                    let bundle_path = worktree
-                        .which("bundle")
-                        .ok_or("Unable to find 'bundle' command: e")?;
+            return self.extension_gemset_language_server_binary(language_server_id);
+        }
 
-                    Ok(LanguageServerBinary {
-                        path: bundle_path,
-                        args: Some(
-                            vec!["exec".into(), Self::EXECUTABLE_NAME.into()]
-                                .into_iter()
-                                .chain(Self::get_executable_args())
-                                .collect(),
-                        ),
-                        env: Some(worktree.shell_env()),
-                    })
-                }
-                Err(_e) => self.extension_gemset_language_server_binary(language_server_id),
+        let bundler = Bundler::new(worktree.root_path());
+        match bundler.installed_gem_version(Self::GEM_NAME) {
+            Ok(_version) => {
+                let bundle_path = worktree
+                    .which("bundle")
+                    .ok_or("Unable to find 'bundle' command: e")?;
+
+                Ok(LanguageServerBinary {
+                    path: bundle_path,
+                    args: Some(
+                        vec!["exec".into(), Self::EXECUTABLE_NAME.into()]
+                            .into_iter()
+                            .chain(Self::get_executable_args())
+                            .collect(),
+                    ),
+                    env: Some(worktree.shell_env()),
+                })
             }
+            Err(_e) => self.extension_gemset_language_server_binary(language_server_id),
         }
     }
 

--- a/src/language_servers/rubocop.rs
+++ b/src/language_servers/rubocop.rs
@@ -5,6 +5,7 @@ pub struct Rubocop {}
 impl LanguageServer for Rubocop {
     const SERVER_ID: &str = "rubocop";
     const EXECUTABLE_NAME: &str = "rubocop";
+    const GEM_NAME: &str = "rubocop";
 
     fn get_executable_args() -> Vec<String> {
         vec!["--lsp".to_string()]

--- a/src/language_servers/rubocop.rs
+++ b/src/language_servers/rubocop.rs
@@ -36,9 +36,4 @@ mod tests {
     fn test_executable_args() {
         assert_eq!(Rubocop::get_executable_args(), vec!["--lsp"]);
     }
-
-    #[test]
-    fn test_default_use_bundler() {
-        assert!(Rubocop::default_use_bundler());
-    }
 }

--- a/src/language_servers/ruby_lsp.rs
+++ b/src/language_servers/ruby_lsp.rs
@@ -10,6 +10,7 @@ pub struct RubyLsp {}
 impl LanguageServer for RubyLsp {
     const SERVER_ID: &str = "ruby-lsp";
     const EXECUTABLE_NAME: &str = "ruby-lsp";
+    const GEM_NAME: &str = "ruby-lsp";
 
     fn default_use_bundler() -> bool {
         false

--- a/src/language_servers/ruby_lsp.rs
+++ b/src/language_servers/ruby_lsp.rs
@@ -11,10 +11,6 @@ impl LanguageServer for RubyLsp {
     const SERVER_ID: &str = "ruby-lsp";
     const EXECUTABLE_NAME: &str = "ruby-lsp";
     const GEM_NAME: &str = "ruby-lsp";
-
-    fn default_use_bundler() -> bool {
-        false
-    }
 }
 
 impl RubyLsp {
@@ -112,10 +108,5 @@ mod tests {
     #[test]
     fn test_executable_args() {
         assert_eq!(RubyLsp::get_executable_args(), vec![] as Vec<String>);
-    }
-
-    #[test]
-    fn test_default_use_bundler() {
-        assert!(!RubyLsp::default_use_bundler());
     }
 }

--- a/src/language_servers/solargraph.rs
+++ b/src/language_servers/solargraph.rs
@@ -9,6 +9,7 @@ pub struct Solargraph {}
 impl LanguageServer for Solargraph {
     const SERVER_ID: &str = "solargraph";
     const EXECUTABLE_NAME: &str = "solargraph";
+    const GEM_NAME: &str = "solargraph";
 
     fn get_executable_args() -> Vec<String> {
         vec!["stdio".to_string()]

--- a/src/language_servers/solargraph.rs
+++ b/src/language_servers/solargraph.rs
@@ -14,6 +14,10 @@ impl LanguageServer for Solargraph {
     fn get_executable_args() -> Vec<String> {
         vec!["stdio".to_string()]
     }
+
+    fn default_use_bundler() -> bool {
+        false
+    }
 }
 
 impl Solargraph {

--- a/src/language_servers/solargraph.rs
+++ b/src/language_servers/solargraph.rs
@@ -14,10 +14,6 @@ impl LanguageServer for Solargraph {
     fn get_executable_args() -> Vec<String> {
         vec!["stdio".to_string()]
     }
-
-    fn default_use_bundler() -> bool {
-        false
-    }
 }
 
 impl Solargraph {
@@ -137,10 +133,5 @@ mod tests {
     #[test]
     fn test_executable_args() {
         assert_eq!(Solargraph::get_executable_args(), vec!["stdio"]);
-    }
-
-    #[test]
-    fn test_default_use_bundler() {
-        assert!(Solargraph::default_use_bundler());
     }
 }

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,3 +1,4 @@
+mod gemset;
 mod language_servers;
 use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,3 +1,4 @@
+mod bundler;
 mod gemset;
 mod language_servers;
 use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};


### PR DESCRIPTION
## Use new process API for starting language servers

Improve initial developer experience of the Ruby extension by utilizing the new `Process` API for starting language servers.

**Key points:**

- The Ruby extension always should prefer LSPs available in project gemset.
- The `binary.path` option acts as a circuit breaker in the activation logic for experienced users and for debugging purposes.

## Test cases

All test cases and current activation logic:

1. If an absolute path `lsp.<LSP_NAME>.binary.path` is available, ignore the `use_bundler` configuration option value and use the provided path.
2. If the `use_bundler` configuration option is **true**: 
   1. Start an LSP with `bundle exec`. In most cases, this will activate the version available in the project's gemset.
3. If the `use_bundler` configuration option is **false**:
4. Check the project's gemset to see if the LSP is available there. See below.
5. If available, use it.
6. Otherwise, check the extension's work dir for the installed LSP.
7. Check for updates.
8. Start the isolated LSP installed in the extension's work dir.

```mermaid
graph TD;
    A[Start] --> B{Absolute path 'binary.path' available?}
    B -->|Yes| C[Use the provided path]
    B -->|No| D{Is 'use_bundler' configuration option true?}
    D -->|Yes| E[Start LSP with bundler]
    D -->|No| G[Check the project's gemset for LSP]
    G --> H{Is LSP available in gemset?}
    H -->|Yes| I[Use the available LSP]
    H -->|No| J[Check the extension's work dir for installed LSP]
    J --> K{Check for updates}
    K --> L[Start isolated LSP in extension's work dir]
    C --> End[End]
    I --> End
    L --> End
```

### solargraph (default)

- Gem name: [`solargraph`](https://rubygems.org/gems/solargraph)
- Uses bundler by default: true

#### Demo

Using `solargraph` from the project' gemset:


https://github.com/user-attachments/assets/0d59084c-a9f3-4666-aaf9-74504fe5fd18


Using `solargraph` from the extenion' gemset:


https://github.com/user-attachments/assets/df329ed2-40e5-4948-b6f4-7afd5caacc48


### ruby-lsp

- Gem name: [`ruby-lsp`](https://rubygems.org/gems/ruby-lsp)
- Uses bundler by default: false

### rubocop

- Gem name: [`rubocop`](https://rubygems.org/gems/rubocop)
- Uses bundler by default: true

## TODO

- [ ] Cover newly added functionality with tests
- [x] Test all supported LSPs
- [x] Edge cases?

## Resources

- [Introducing the use_bundler configuration option](https://github.com/zed-extensions/ruby/issues/16)