### PR TITLE
Add support for Standard Ruby's LSP server

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -18,6 +18,10 @@ languages = ["Ruby", "ERB"]
 name = "Rubocop"
 languages = ["Ruby"]
 
+[language_servers.standard]
+name = "Standard"
+languages = ["Ruby"]
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "71bd32fb7607035768799732addba884a37a6210"

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -2,8 +2,10 @@ mod language_server;
 mod rubocop;
 mod ruby_lsp;
 mod solargraph;
+mod standard;
 
 pub use language_server::LanguageServer;
 pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;
+pub use standard::*;

--- a/src/language_servers/standard.rs
+++ b/src/language_servers/standard.rs
@@ -1,0 +1,43 @@
+use super::LanguageServer;
+
+pub struct Standard {}
+
+impl LanguageServer for Standard {
+    const SERVER_ID: &str = "standard";
+    const EXECUTABLE_NAME: &str = "standardrb";
+
+    fn get_executable_args() -> Vec<String> {
+        vec!["--lsp".to_string()]
+    }
+}
+
+impl Standard {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::language_servers::{LanguageServer, Standard};
+
+    #[test]
+    fn test_server_id() {
+        assert_eq!(Standard::SERVER_ID, "standard");
+    }
+
+    #[test]
+    fn test_executable_name() {
+        assert_eq!(Standard::EXECUTABLE_NAME, "standardrb");
+    }
+
+    #[test]
+    fn test_executable_args() {
+        assert_eq!(Standard::get_executable_args(), vec!["--lsp"]);
+    }
+
+    #[test]
+    fn test_default_use_bundler() {
+        assert!(Standard::default_use_bundler());
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -1,5 +1,5 @@
 mod language_servers;
-use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph};
+use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph, Standard};
 
 use zed::lsp::{Completion, Symbol};
 use zed::settings::LspSettings;
@@ -11,6 +11,7 @@ struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
     rubocop: Option<Rubocop>,
+    standard: Option<Standard>,
 }
 
 impl zed::Extension for RubyExtension {
@@ -35,6 +36,10 @@ impl zed::Extension for RubyExtension {
             Rubocop::SERVER_ID => {
                 let rubocop = self.rubocop.get_or_insert_with(Rubocop::new);
                 rubocop.language_server_command(language_server_id, worktree)
+            }
+            Standard::SERVER_ID => {
+                let standard = self.standard.get_or_insert_with(Standard::new);
+                standard.language_server_command(language_server_id, worktree)
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }


### PR DESCRIPTION
Since pull-based diagnostics aren't supported [yet](https://github.com/zed-industries/zed/pull/19230), I wanted to see if it's possible to use Standard's built-in language server for diagnostics, but Ruby LSP for everything else.

Since Standard's LSP is based on RoboCop's, I've basically just copied the existing RuboCop implementation.

So far it appears to be working well. I was concerned about what might happen if format requests were sent to multiple language servers. But it seems the request is only sent to the first in the `language_servers` array.

If this is merged then the [Ruby docs page](https://github.com/zed-industries/zed/blob/main/docs/src/languages/ruby.md) should be updated to mention Standard.