### PR TITLE
Add snippets

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -220,3 +220,15 @@ Apache License
 
 
    END OF TERMS AND CONDITIONS
+
+---
+
+The contents of snippets.json are derived from Ruby LSP:
+
+https://github.com/Shopify/ruby-lsp
+    https://github.com/Shopify/ruby-lsp/blob/main/vscode/LICENSE.txt
+
+which are in turn derived from:
+
+https://github.com/textmate/ruby.tmbundle
+    https://github.com/textmate/ruby.tmbundle#license

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -225,10 +225,8 @@ Apache License
 
 The contents of snippets.json are derived from Ruby LSP:
 
-https://github.com/Shopify/ruby-lsp
+    Copyright (c) 2022-present, Shopify Inc.
+    https://github.com/Shopify/ruby-lsp
+
+    Released under the MIT license
     https://github.com/Shopify/ruby-lsp/blob/main/vscode/LICENSE.txt
-
-which are in turn derived from:
-
-https://github.com/textmate/ruby.tmbundle
-    https://github.com/textmate/ruby.tmbundle#license

--- a/extension.toml
+++ b/extension.toml
@@ -5,6 +5,7 @@ version = "0.4.6"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"
+snippets = "snippets.json"
 
 [language_servers.solargraph]
 name = "Solargraph"

--- a/snippets.json
+++ b/snippets.json
@@ -1,0 +1,155 @@
+{
+  "New Minitest spec": {
+    "prefix": ["Minitest"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "require \"spec_helper\"",
+      "",
+      "class $1 < Minitest::Spec",
+      "  describe \"$2\" do",
+      "    it \"$3\" do",
+      "      $0",
+      "      assert(true)",
+      "    end",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the spec syntax."
+  },
+  "New Minitest test": {
+    "prefix": ["Minitest"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "require \"test_helper\"",
+      "",
+      "class $1 < Minitest::Test",
+      "  def test_$2",
+      "    $0",
+      "    assert(true)",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the test syntax."
+  },
+  "New Rspec test": {
+    "prefix": ["Rspec"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "describe $1 do",
+      "  describe \"$2\" do",
+      "    it \"$3\" do",
+      "      $0",
+      "      expect(true).to eq(true)",
+      "    end",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the spec syntax."
+  },
+  "New class": {
+    "prefix": ["class"],
+    "body": ["class $1", "  def initialize", "    $0", "  end", "end", ""],
+    "description": "New Ruby class."
+  },
+  "New module": {
+    "prefix": ["module"],
+    "body": ["module $1", "  def $2", "    $0", "  end", "end", ""],
+    "description": "New Ruby module."
+  },
+  "Begin rescue block": {
+    "prefix": ["begin"],
+    "body": ["begin", "  $0", "rescue $1", "end", ""],
+    "description": "New Ruby begin block with rescue."
+  },
+  "Begin rescue ensure": {
+    "prefix": ["begin"],
+    "body": ["begin", "  $0", "rescue $1", "ensure", "end", ""],
+    "description": "New Ruby begin block with rescue and ensure."
+  },
+  "Each inline": {
+    "prefix": ["each"],
+    "body": ["each { |$1| $0 }"],
+    "description": "New Ruby inline each loop."
+  },
+  "Each block": {
+    "prefix": ["each"],
+    "body": ["each do |$1|", "  $0", "end"],
+    "description": "New Ruby each loop."
+  },
+  "Map inline": {
+    "prefix": ["map"],
+    "body": ["map { |$1| $0 }"],
+    "description": "New Ruby inline map loop."
+  },
+  "Map block": {
+    "prefix": ["map"],
+    "body": ["map do |$1|", "  $0", "end"],
+    "description": "New Ruby map loop."
+  },
+  "Flat map inline": {
+    "prefix": ["flat_map"],
+    "body": ["flat_map { |$1| $0 }"],
+    "description": "New Ruby inline flat_map loop."
+  },
+  "Flat Map block": {
+    "prefix": ["flat_map"],
+    "body": ["flat_map do |$1|", "  $0", "end"],
+    "description": "New Ruby flat_map loop."
+  },
+  "Select inline": {
+    "prefix": ["select"],
+    "body": ["select { |$1| $0 }"],
+    "description": "New Ruby inline select loop."
+  },
+  "Select block": {
+    "prefix": ["select"],
+    "body": ["select do |$1|", "  $0", "end"],
+    "description": "New Ruby select loop."
+  },
+  "Find inline": {
+    "prefix": ["find"],
+    "body": ["find { |$1| $0 }"],
+    "description": "New Ruby inline find loop."
+  },
+  "Find block": {
+    "prefix": ["find"],
+    "body": ["find do |$1|", "  $0", "end"],
+    "description": "New Ruby find loop."
+  },
+  "Define singleton method": {
+    "prefix": ["def"],
+    "body": ["def self.$1", "  $0", "end"],
+    "description": "New singleton method."
+  },
+  "Define attribute accessor": {
+    "prefix": ["attr"],
+    "body": ["attr_accessor :$1"],
+    "description": "New attribute accessor."
+  },
+  "Define attribute reader": {
+    "prefix": ["attr"],
+    "body": ["attr_reader :$1"],
+    "description": "New attribute reader."
+  },
+  "Define attribute writer": {
+    "prefix": ["attr"],
+    "body": ["attr_writer :$1"],
+    "description": "New attribute writer."
+  },
+  "If else": {
+    "prefix": ["if"],
+    "body": ["if $1", "  $0", "else", "end"],
+    "description": "New if statement with else."
+  },
+  "If elsif": {
+    "prefix": ["if"],
+    "body": ["if $1", "  $0", "elsif $2", "  $0", "end"],
+    "description": "New if statement with elsif."
+  }
+}

--- a/snippets.json
+++ b/snippets.json
@@ -128,7 +128,7 @@
     "description": "New method."
   },
   "Define singleton method": {
-    "prefix": ["def"],
+    "prefix": ["defs"],
     "body": ["def self.$1", "  $0", "end"],
     "description": "New singleton method."
   },

--- a/snippets.json
+++ b/snippets.json
@@ -122,6 +122,11 @@
     "body": ["find do |$1|", "  $0", "end"],
     "description": "New Ruby find loop."
   },
+  "Define method method": {
+    "prefix": ["def"],
+    "body": ["def $1", "  $0", "end"],
+    "description": "New method."
+  },
   "Define singleton method": {
     "prefix": ["def"],
     "body": ["def self.$1", "  $0", "end"],


### PR DESCRIPTION
This PR adds a set of snippets to the add-on (see https://zed.dev/docs/snippets)

~They were added to Ruby LSP in https://github.com/Shopify/vscode-ruby-lsp/pull/150. I believe they were derived from [Textmate's Ruby bundle](https://github.com/textmate/ruby.tmbundle).~ (incorrect)

The `vscode-ruby-lsp` repo was later combined into the `ruby-lsp` repo, so they now live at https://github.com/Shopify/ruby-lsp/blob/main/vscode/snippets.json. The file I'm adding here is an exact copy that file.

I think there's a opportunity to improve the snippets, so consider this as a starting point.

~I'm currently investigating why snippets are appearing twice:~ solved by https://github.com/zed-industries/zed/pull/28940

Note: It's possible that snippet completion may be later moved into the LSP: https://github.com/Shopify/ruby-lsp/issues/1874

TODO:
- [x] Check if the `LICENSE` needs updated to mention that these were sourced from Ruby LSP.
- [x] Wait for https://github.com/zed-industries/zed/issues/15846