### PR TITLE
Specify `?` and `!` as word characters

### DIFF
--- a/languages/erb/config.toml
+++ b/languages/erb/config.toml
@@ -7,3 +7,4 @@ brackets = [
 ]
 block_comment = ["<%#", "%>"]
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
+word_characters = ["?", "!"]

--- a/languages/rbs/config.toml
+++ b/languages/rbs/config.toml
@@ -8,3 +8,4 @@ brackets = [
     { start = "[", end = "]", close = true, newline = false },
 ]
 line_comments = ["#"]
+word_characters = ["?", "!"]

--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -59,6 +59,7 @@ brackets = [
 collapsed_placeholder = "# ..."
 tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
+word_characters = ["?", "!"]
 
 [overrides.string]
 completion_query_characters = ["-"]


### PR DESCRIPTION
See https://zed.dev/docs/extensions/languages#syntax-overrides

I am considering whether to also add:

* `:` (for symbols)
* `@` (for instance variables)