### PR TITLE
Add constants to outline view

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -19,6 +19,12 @@
     "module" @context
     name: (_) @name) @item
 
+
+(assignment
+    (((constant) @constant
+    (#match? @constant "^[A-Z\\d_]")) @name
+) @item)
+
 ; Support Minitest/RSpec symbols
 ;
 ; Note that `(_)+` is used to capture one more child nodes, meaning it will also include any modifier symbols, like


### PR DESCRIPTION
## Description

Adds constants assignments to the symbols outline.
According to the Ruby specification almost everything is a constant:

```ruby
class ApplicationController # ApplicationController is a constant
Bar = :bar # Bar is a constant
BAR = 1 # BAR is a constant
Bar = Class.new # Bar is a constant
```

The challenge is to show only the most necessary symbols in the symbols outline. Pulling all constants results in an output where class declarations are shown as well, and this is not what we want. The solution is to pull only assigned constants. We are fortunate here because, otherwise, the Ruby interpreter would produce an uninitialized constant error. Consider the following code:

```ruby
# frozen_string_literal: true

ABC = 1
Goo = 2
Foo = 3

foo = 1

class Category < ApplicationRecord
  validates :name, presence: true, length: { maximum: 255 }, uniqueness: true
  validates :hidden, inclusion: { in: [ true, false ] }
end

class RubyBlog
  URL    = "rubyguides.com"
  AUTHOR = "Jesus Castello"
  SomeError = "Jesus Castello"
end
```

Opening the symbols outline panel produces the following:

![image](https://github.com/user-attachments/assets/8b89eed5-b023-4e63-8469-86b7918421f3)


Closes https://github.com/zed-extensions/ruby/issues/50