### PR TITLE
Capture constants with assignments only for outline panel

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -19,11 +19,7 @@
     "module" @context
     name: (_) @name) @item
 
-
-(assignment
-    (((constant) @constant
-    (#match? @constant "^[A-Z\\d_]")) @name
-) @item)
+(assignment left: (constant) @name) @item
 
 ; Support Minitest/RSpec symbols
 ;


### PR DESCRIPTION
[Previous version](https://github.com/zed-extensions/ruby/pull/60) captures constant assignments to constants:

```ruby
Left = Right
```

In the snippet above, we capture both constants `Left` and `Right` but we need `Left` only. This commit improves the TS query to capture only the left side of the assignment.

|Before|After|
|----|----|
|![CleanShot 2025-04-15 at 21 32 00@2x](https://github.com/user-attachments/assets/173a24fe-34ed-41a2-b5b4-7e8cc8b8d1ea)|![CleanShot 2025-04-15 at 21 32 21@2x](https://github.com/user-attachments/assets/9893b631-bd44-4b38-abaf-8ec19a2c3392)|


