### PR TITLE
Fix missing Tailwind completions

### DIFF
--- a/languages/erb/config.toml
+++ b/languages/erb/config.toml
@@ -2,9 +2,6 @@ name = "ERB"
 grammar = "embedded_template"
 path_suffixes = ["erb"]
 autoclose_before = ">})"
-brackets = [
-    { start = "<", end = ">", close = true, newline = true },
-]
+brackets = [{ start = "<", end = ">", close = true, newline = true }]
 block_comment = ["<%#", "%>"]
-scope_opt_in_language_servers = ["tailwindcss-language-server"]
 word_characters = ["?", "!"]

--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -38,7 +38,7 @@ path_suffixes = [
     "Deliverfile",
     "Scanfile",
     "Snapfile",
-    "Gymfile"
+    "Gymfile",
 ]
 first_line_pattern = '^#!.*\bruby\b'
 line_comments = ["# "]
@@ -62,5 +62,5 @@ scope_opt_in_language_servers = ["tailwindcss-language-server"]
 word_characters = ["?", "!"]
 
 [overrides.string]
-completion_query_characters = ["-"]
+completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]

--- a/languages/ruby/overrides.scm
+++ b/languages/ruby/overrides.scm
@@ -1,0 +1,3 @@
+(comment) @comment.inclusive
+
+(string) @string


### PR DESCRIPTION
Currently, the tailwind auto completions is missing in Ruby / ERB. See: zed-industries/zed/issues/27118

After modifying the overrides:

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/2950b3f5-399d-4371-aa51-77737f67dc33" />
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/2a495f4a-eb7b-4bf6-92fe-6f8b0fccb516" />


In fact, these are just patches borrowed from the PR (zed-industries/zed/pull/28674) for Rust. I'm not familiar with Ruby, so I can't do more thorough testing.