### PR TITLE
Mark instance & class variables as "@variable.special"

### DIFF
--- a/languages/ruby/highlights.scm
+++ b/languages/ruby/highlights.scm
@@ -101,7 +101,7 @@
 [
   (class_variable)
   (instance_variable)
-] @variable.member
+] @variable.special
 
 ((call
   !receiver


### PR DESCRIPTION
This name is already used by the default themes one and gruvbox. I think there's a good chance that the unofficial themes also define it.