### PR TITLE
Fix visibility keywords in outline

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -2,8 +2,10 @@
     "class" @context
     name: (_) @name) @item
 
-((identifier) @context
-  (#match? @context "^(private|protected|public)$")) @item
+(body_statement
+    ((identifier) @context
+    (#match? @context "^(private|protected|public)$")) @item
+)
 
 (method
     "def" @context


### PR DESCRIPTION
This PR fixes the visibility keywords in the outline. Specifically, it excludes the visibility keyword query from matching when the method is used as a modifier directly before a method definition:

```ruby
private def foo
end
```

...or when it is used to change the visibility of a method by its symbol name

```ruby
private :foo
```

This partly fixes #64. I’ll follow up with a PR to add support for visibility modifiers next to method definitions.

Here’s a full example:

```ruby
module Example
  def a
  end

  private :foo
  protectd :bar
  public :bing

  private def b
  end

  def c
  end

  protected def d
  end

  def e
  end

  protected

  def f
  end

  private

  def g
  end
end
```

<img width="624" alt="Screenshot 2025-04-18 at 12 43 26" src="https://github.com/user-attachments/assets/85fbd4b0-b2f4-48c7-a2ef-af1494559d85" />

Previous behaviour:

<img width="673" alt="Screenshot 2025-04-18 at 12 46 58" src="https://github.com/user-attachments/assets/faaedd03-89f3-432d-92e1-d6fe46ab86d2" />

