### PR TITLE
Include method modifiers in outline

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -5,9 +5,21 @@
 ((identifier) @context
   (#match? @context "^(private|protected|public)$")) @item
 
-(method
-    "def" @context
-    name: (_) @name) @item
+(body_statement
+  (call
+      method: (identifier) @context
+      arguments: (argument_list
+          (method
+              "def" @context
+              name: (_) @name)
+          )) @item
+)
+
+(body_statement
+    (method
+        "def" @context
+        name: (_) @name) @item
+)
 
 (singleton_method
     "def" @context

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -21,6 +21,22 @@
         name: (_) @name) @item
 )
 
+(program
+  (call
+      method: (identifier) @context
+      arguments: (argument_list
+          (method
+              "def" @context
+              name: (_) @name)
+          )) @item
+)
+
+(program
+    (method
+        "def" @context
+        name: (_) @name) @item
+)
+
 (singleton_method
     "def" @context
     object: (_) @context


### PR DESCRIPTION
Following #65, this PR updates the method queries so that they include modifiers as part of the outline.

A method like this:

```ruby
private def foo
end
```

...would appear in the outline as:

```
private def foo
```

I’ve specifically not limited this to the keywords `public`, `private`, `protected` because you can define your own modifiers like `deprecated`, `final`, etc.