### PR TITLE
Include singleton class in outline

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -2,6 +2,12 @@
     "class" @context
     name: (_) @name) @item
 
+(singleton_class
+    "class" @context
+    "<<" @context
+    value: (self) @context
+) @item
+
 ((identifier) @context
   (#match? @context "^(private|protected|public)$")) @item
 


### PR DESCRIPTION
This PR adds a selector for singleton classes. Here’s an example:

```ruby
class Foo
  class << self
    def bar
    end
  end
  
  def baz
  end
end
```

<img width="683" alt="Screenshot 2025-04-18 at 13 14 27" src="https://github.com/user-attachments/assets/2423fbdf-aa30-45ec-9181-dacb7089f64a" />
