### PR TITLE
Improve Ruby outlines with macros

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.scm]
+indent_style = space
+indent_size = 4

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -1,67 +1,182 @@
+; Class definitions, e.g. `class Foo`
 (class
     "class" @context
     name: (_) @name) @item
 
+; Singleton class definitions `class << self`
 (singleton_class
     "class" @context
     "<<" @context
     value: (self) @context
 ) @item
 
+; Method definition with a modifier, e.g. `private def foo`
 (body_statement
-    ((identifier) @context
-    (#match? @context "^(private|protected|public)$")) @item
+    (call
+        method: (identifier) @context
+        arguments: (argument_list
+            (method
+                "def" @context
+                name: (_) @name)
+            )) @item
 )
 
-(body_statement
-  (call
-      method: (identifier) @context
-      arguments: (argument_list
-          (method
-              "def" @context
-              name: (_) @name)
-          )) @item
-)
-
+; Method definition without modieifer, e.g. `def foo`
 (body_statement
     (method
         "def" @context
         name: (_) @name) @item
 )
 
+; Root method definition with modifier, e.g. `private def foo`
 (program
-  (call
-      method: (identifier) @context
-      arguments: (argument_list
-          (method
-              "def" @context
-              name: (_) @name)
-          )) @item
+    (call
+        method: (identifier) @context
+        arguments: (argument_list
+            (method
+                "def" @context
+                name: (_) @name)
+            )) @item
 )
 
+; Root method definition without modifier, e.g. `def foo`
 (program
     (method
         "def" @context
         name: (_) @name) @item
 )
 
-(singleton_method
-    "def" @context
-    object: (_) @context
-    "." @context
-    name: (_) @name) @item
+; Root singleton method definition, e.g. `def self.foo`
+(program
+    (singleton_method
+        "def" @context
+        object: (_) @context
+        "." @context
+        name: (_) @name) @item
+)
 
+; Singleton method definition without modifier, e.g. `def self.foo`
+(body_statement
+    (singleton_method
+        "def" @context
+        object: (_) @context
+        "." @context
+        name: (_) @name) @item
+)
+
+; Singleton method definition with modifier, e.g. `private_class_method def self.foo`
+(body_statement
+    (call
+        method: (identifier) @context
+        arguments: (argument_list
+            (singleton_method
+                "def" @context
+                object: (_) @context
+                "." @context
+                name: (_) @name) @item
+            )) @item
+)
+
+; Module definition, e.g. `module Foo`
 (module
     "module" @context
     name: (_) @name) @item
 
+; Constant assignment
 (assignment left: (constant) @name) @item
 
-; Support Minitest/RSpec symbols
-;
-; Note that `(_)+` is used to capture one more child nodes, meaning it will also include any modifier symbols, like
-; :focus, so that we can easily jump to focused tests
-(call
-    method: (identifier) @run (#any-of? @run "describe" "context" "test" "it")
-    arguments: (argument_list . (_)+) @name
-) @item
+; Class macros such as `alias_method`, `include`, `belongs_to`, `has_many`, `attr_reader`
+(class
+    (body_statement
+        (call
+            method: (identifier) @name
+            arguments: (argument_list . [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                    "," @context
+                ]* [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                ]
+            )
+        ) @item
+    )
+)
+
+; Module macros such as `alias_method`, `include`
+(module
+    (body_statement
+        (call
+            method: (identifier) @name
+            arguments: (argument_list . [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                    "," @context
+                ]* [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                ]
+            )
+        ) @item
+    )
+)
+
+; Class macros without arguments, such as `private`
+(class
+    (body_statement
+        (identifier) @name @item
+    )
+)
+
+(class
+    (body_statement
+        (call
+            method: (identifier) @name
+            !arguments
+        ) @item
+    )
+)
+
+; Module macros without arguments, such as `private`
+(module
+    (body_statement
+        (identifier) @name @item
+    )
+)
+
+(module
+    (body_statement
+        (call
+            method: (identifier) @name
+            !arguments
+        ) @item
+    )
+)
+
+; Root test block
+(program
+    (call
+        method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+        arguments: (argument_list . [
+                (string) @name
+                (simple_symbol) @name
+                (scope_resolution) @name
+                (constant) @name
+                "," @context
+            ]* [
+                (string) @name
+                (simple_symbol) @name
+                (scope_resolution) @name
+                (constant) @name
+            ]
+        )?
+    ) @item
+)


### PR DESCRIPTION
This PR makes some substantial changes to the TreeSitter queries for Ruby outlines. It’s quite complicated but I’ll try to cover everything the new queries match with a few examples below.

The significant change here is that we now match macros (methods called with an implicit receiver directly in a class or module). The visibility macros `private`, `protected` and `public` as well as the test macros `test`, `it`, `describe`, etc. and macros like `include`, `belongs_to`, and `alias_method` are all covered.

I believe this closes #45 without introducing any Rails-specific matchers.

### Class definitions
**Buffer:**
```ruby
class Foo
end
```

**Outline:**
```
class Foo
```

### Singleton class definition
**Buffer:**
```ruby
class Foo
  class << self
  end
end
```

**Outline:**
```
class Foo
  class << self
```

### Method definition with modifier
**Buffer:**
```ruby
class Foo
  private def bar
  end
end
```

**Outline:**
```
class Foo
  private def bar
```

### Method definition without modifier
**Buffer:**
```ruby
class Foo
  def bar
  end
end
```

**Outline:**
```
class Foo
  def bar
```

### Root method definition with modifier
**Buffer:**
```ruby
private def foo
end
```

**Outline:**
```
private def foo
```

### Root method definition without modifier
**Buffer:**
```ruby
def foo
end
```

**Outline:**
```
def foo
```

### Root singleton method definition
**Buffer:**
```ruby
def Something.foo
end
```

**Outline:**
```
def Something.foo
```

### Singleton method definition without modifier

**Buffer:**
```ruby
class Foo
  def self.bar
  end
end
```

**Outline:**
```
class Foo
  def self.bar
```

### Singleton method definition with modifier

**Buffer:**

```ruby
class Foo
  private_class_method def self.bar
  end
end
```

**Outline:**
```
class Foo
  private_class_method def self.bar
```

### Module definition


**Buffer:**

```ruby
module Foo
end
```

**Outline:**
```
module Foo
```

### Constant assignment

**Buffer:**
```ruby
Foo = 1
```

**Outline:**
```
Foo
```

### Class macros

**Buffer:**
```ruby
class Foo
  include Bar
  belongs_to :foo
  has_many :whatever
  alias_method :a, :b
end
```

**Outline:**
```
class Foo
  include Bar
  belongs_to :foo
  has_many :whatever
  alias_method :a, :b
```

### Module macros

**Buffer:**
```ruby
module Foo
  include Bar
  belongs_to :foo
  has_many :whatever
  alias_method :a, :b
end
```

**Outline:**
```
module Foo
  include Bar
  belongs_to :foo
  has_many :whatever
  alias_method :a, :b
```

### Class macros without arguments

**Buffer:**
```ruby
class Foo
  private
  important!
end
```

**Outline:**
```
class Foo
  private
  important!
```

### Module macros without arguments

**Buffer:**
```ruby
module Foo
  private
  important!
end
```

**Outline:**
```
module Foo
  private
  important!
```

### Root test blocks

**Buffer:**
```ruby
test "foo", :focus do
end
```

**Outline:**
```
test "foo", :focus
```