### PR TITLE
Fix RSpec outlines

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -162,19 +162,185 @@
 )
 
 ; Test methods
-(call
+; Level 1
+(program
+  (call
+    receiver: [
+      (constant) @receiver (#eq? @receiver "RSpec")
+      (nil)
+    ]
     method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
     arguments: (argument_list . [
-            (string) @name
-            (simple_symbol) @name
-            (scope_resolution) @name
-            (constant) @name
-            "," @context
-        ]* [
-            (string) @name
-            (simple_symbol) @name
-            (scope_resolution) @name
-            (constant) @name
-        ]
-    )?
-) @item
+        (string) @name
+        (simple_symbol) @name
+        (scope_resolution) @name
+        (constant) @name
+        "," @context
+      ]* [
+        (string) @name
+        (simple_symbol) @name
+        (scope_resolution) @name
+        (constant) @name
+      ]
+    )
+  ) @item
+)
+
+; Test methods
+; Level 2
+(program
+  (call
+    receiver: [
+      (constant) @receiver (#eq? @receiver "RSpec")
+      (nil)
+    ]
+    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+    arguments: (argument_list . [
+        (string)
+        (simple_symbol)
+        (scope_resolution)
+        (constant)
+      ]+
+    )
+    block: (_
+      (_
+        (call
+          method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+          arguments: (argument_list . [
+              (string) @name
+              (simple_symbol) @name
+              (scope_resolution) @name
+              (constant) @name
+              "," @context
+            ]* [
+              (string) @name
+              (simple_symbol) @name
+              (scope_resolution) @name
+              (constant) @name
+            ]
+          )
+        ) @item
+      )
+    )
+  )
+)
+
+; Test methods
+; Level 3
+(program
+  (call
+    receiver: [
+      (constant) @receiver (#eq? @receiver "RSpec")
+      (nil)
+    ]
+    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+    arguments: (argument_list . [
+        (string)
+        (simple_symbol)
+        (scope_resolution)
+        (constant)
+      ]+
+    )
+    block: (_
+      (_
+        (call
+          method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+          arguments: (argument_list . [
+              (string)
+              (simple_symbol)
+              (scope_resolution)
+              (constant)
+            ]+
+          )
+          block: (_
+            (_
+              (call
+                method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+                arguments: (argument_list . [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                    "," @context
+                  ]* [
+                    (string) @name
+                    (simple_symbol) @name
+                    (scope_resolution) @name
+                    (constant) @name
+                  ]
+                )
+              ) @item
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+; Test methods
+; Level 4
+(program
+  (call
+    receiver: [
+      (constant) @receiver (#eq? @receiver "RSpec")
+      (nil)
+    ]
+    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+    arguments: (argument_list . [
+        (string)
+        (simple_symbol)
+        (scope_resolution)
+        (constant)
+      ]+
+    )
+    block: (_
+      (_
+        (call
+          method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+          arguments: (argument_list . [
+              (string)
+              (simple_symbol)
+              (scope_resolution)
+              (constant)
+            ]+
+          )
+          block: (_
+            (_
+              (call
+                method: (identifier) @ctx (#any-of? @ctx "describe" "context")
+                arguments: (argument_list . [
+                    (string)
+                    (simple_symbol)
+                    (scope_resolution)
+                    (constant)
+                  ]+
+                )
+                block: (_
+                  (_
+                    (call
+                      method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+                      arguments: (argument_list . [
+                          (string) @name
+                          (simple_symbol) @name
+                          (scope_resolution) @name
+                          (constant) @name
+                          "," @context
+                        ]* [
+                          (string) @name
+                          (simple_symbol) @name
+                          (scope_resolution) @name
+                          (constant) @name
+                        ]
+                      )
+                    ) @item
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -161,22 +161,20 @@
     )
 )
 
-; Root test block
-(program
-    (call
-        method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
-        arguments: (argument_list . [
-                (string) @name
-                (simple_symbol) @name
-                (scope_resolution) @name
-                (constant) @name
-                "," @context
-            ]* [
-                (string) @name
-                (simple_symbol) @name
-                (scope_resolution) @name
-                (constant) @name
-            ]
-        )?
-    ) @item
-)
+; Test methods
+(call
+    method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+    arguments: (argument_list . [
+            (string) @name
+            (simple_symbol) @name
+            (scope_resolution) @name
+            (constant) @name
+            "," @context
+        ]* [
+            (string) @name
+            (simple_symbol) @name
+            (scope_resolution) @name
+            (constant) @name
+        ]
+    )?
+) @item

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -161,15 +161,14 @@
     )
 )
 
-; Test methods
-; Level 1
+; Root test methods
 (program
   (call
     receiver: [
       (constant) @receiver (#eq? @receiver "RSpec")
       (nil)
     ]
-    method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
+    method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it" "shared_examples")
     arguments: (argument_list . [
         (string) @name
         (simple_symbol) @name
@@ -186,161 +185,38 @@
   ) @item
 )
 
-; Test methods
-; Level 2
-(program
-  (call
-    receiver: [
-      (constant) @receiver (#eq? @receiver "RSpec")
-      (nil)
-    ]
-    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-    arguments: (argument_list . [
-        (string)
-        (simple_symbol)
-        (scope_resolution)
-        (constant)
-      ]+
-    )
-    block: (_
-      (_
-        (call
-          method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
-          arguments: (argument_list . [
-              (string) @name
-              (simple_symbol) @name
-              (scope_resolution) @name
-              (constant) @name
-              "," @context
-            ]* [
-              (string) @name
-              (simple_symbol) @name
-              (scope_resolution) @name
-              (constant) @name
-            ]
-          )
-        ) @item
-      )
-    )
+; Nested test methods
+(call
+  receiver: [
+    (constant) @receiver (#eq? @receiver "RSpec")
+    (nil)
+  ]
+  method: (identifier) @ctx (#any-of? @ctx "describe" "context" "shared_examples")
+  arguments: (argument_list . [
+      (string)
+      (simple_symbol)
+      (scope_resolution)
+      (constant)
+    ]+
   )
-)
-
-; Test methods
-; Level 3
-(program
-  (call
-    receiver: [
-      (constant) @receiver (#eq? @receiver "RSpec")
-      (nil)
-    ]
-    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-    arguments: (argument_list . [
-        (string)
-        (simple_symbol)
-        (scope_resolution)
-        (constant)
-      ]+
-    )
-    block: (_
-      (_
-        (call
-          method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-          arguments: (argument_list . [
-              (string)
-              (simple_symbol)
-              (scope_resolution)
-              (constant)
-            ]+
-          )
-          block: (_
-            (_
-              (call
-                method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
-                arguments: (argument_list . [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
-                    "," @context
-                  ]* [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
-                  ]
-                )
-              ) @item
-            )
-          )
+  block: (_
+    (_
+      (call
+        method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it" "shared_examples")
+        arguments: (argument_list . [
+            (string) @name
+            (simple_symbol) @name
+            (scope_resolution) @name
+            (constant) @name
+            "," @context
+          ]* [
+            (string) @name
+            (simple_symbol) @name
+            (scope_resolution) @name
+            (constant) @name
+          ]
         )
-      )
-    )
-  )
-)
-
-; Test methods
-; Level 4
-(program
-  (call
-    receiver: [
-      (constant) @receiver (#eq? @receiver "RSpec")
-      (nil)
-    ]
-    method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-    arguments: (argument_list . [
-        (string)
-        (simple_symbol)
-        (scope_resolution)
-        (constant)
-      ]+
-    )
-    block: (_
-      (_
-        (call
-          method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-          arguments: (argument_list . [
-              (string)
-              (simple_symbol)
-              (scope_resolution)
-              (constant)
-            ]+
-          )
-          block: (_
-            (_
-              (call
-                method: (identifier) @ctx (#any-of? @ctx "describe" "context")
-                arguments: (argument_list . [
-                    (string)
-                    (simple_symbol)
-                    (scope_resolution)
-                    (constant)
-                  ]+
-                )
-                block: (_
-                  (_
-                    (call
-                      method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it")
-                      arguments: (argument_list . [
-                          (string) @name
-                          (simple_symbol) @name
-                          (scope_resolution) @name
-                          (constant) @name
-                          "," @context
-                        ]* [
-                          (string) @name
-                          (simple_symbol) @name
-                          (scope_resolution) @name
-                          (constant) @name
-                        ]
-                      )
-                    ) @item
-                  )
-                )
-              )
-            )
-          )
-        )
-      )
+      ) @item
     )
   )
 )

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -164,10 +164,6 @@
 ; Root test methods
 (program
   (call
-    receiver: [
-      (constant) @receiver (#eq? @receiver "RSpec")
-      (nil)
-    ]
     method: (identifier) @run @name (#any-of? @run "describe" "context" "test" "it" "shared_examples")
     arguments: (argument_list . [
         (string) @name
@@ -187,10 +183,6 @@
 
 ; Nested test methods
 (call
-  receiver: [
-    (constant) @receiver (#eq? @receiver "RSpec")
-    (nil)
-  ]
   method: (identifier) @ctx (#any-of? @ctx "describe" "context" "shared_examples")
   arguments: (argument_list . [
       (string)
@@ -216,6 +208,33 @@
             (constant) @name
           ]
         )
+      ) @item
+    )
+  )
+)
+
+; RSpec one-liners
+(call
+  method: (identifier) @ctx (#any-of? @ctx "describe" "context" "shared_examples")
+  arguments: (argument_list . [
+      (string)
+      (simple_symbol)
+      (scope_resolution)
+      (constant)
+    ]+
+  )
+  block: (_
+    (_
+      (call
+        method: (identifier) @run @name (#any-of? @run "it")
+        block: (block
+          body: (block_body
+            (call
+              receiver: (identifier) @expectation (#any-of? @expectation "is_expected")
+              method: (identifier) @negation (#any-of? @negation "to" "not_to" "to_not")
+            )
+          )
+        ) @name
       ) @item
     )
   )


### PR DESCRIPTION
Draft to fix #77 

I need to verify there aren’t any unintended consequences of removing the outer `class` and `module` selectors.