### PR TITLE
v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruby"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruby"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.5.6"
+version = "0.6.0"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"


### PR DESCRIPTION
# Release v0.6.0

## What's changed

- [Fix RSpec outlines (](https://github.com/zed-extensions/ruby/commit/2d2b5dda4ce7ee6e95d6efe708342f618b75440c)https://github.com/zed-extensions/ruby/pull/78[)](https://github.com/zed-extensions/ruby/commit/2d2b5dda4ce7ee6e95d6efe708342f618b75440c)
- [Update Rust crate zed_extension_api to 0.5.0 (](https://github.com/zed-extensions/ruby/commit/047b3fda48eea1813c725056b5757aab1c8ed9ce)https://github.com/zed-extensions/ruby/pull/44[)](https://github.com/zed-extensions/ruby/commit/047b3fda48eea1813c725056b5757aab1c8ed9ce)

Given that I failed to properly release v0.5.6 last time, and we’ve since landed an update to the `zed_extension_api` crate, I think we can go ahead and release v0.6.0 to follow SemVer and indicate a minor change.