### PR TITLE
Improve language server binary lookup in PATH

### DIFF
--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -85,7 +85,18 @@ pub trait LanguageServer {
                     env: Some(worktree.shell_env()),
                 })
             }
-            Err(_e) => self.extension_gemset_language_server_binary(language_server_id),
+            Err(_e) => {
+                // If a requested LS is not available via bundler, check if it's available via PATH
+                if let Some(path) = worktree.which(Self::EXECUTABLE_NAME) {
+                    return Ok(LanguageServerBinary {
+                        path,
+                        args: Some(Self::get_executable_args()),
+                        env: Some(worktree.shell_env()),
+                    });
+                }
+
+                self.extension_gemset_language_server_binary(language_server_id)
+            }
         }
     }
 


### PR DESCRIPTION
Add a fallback to check `PATH` when a language server is not available via `bundler`. Use the system-available binary when it exists in `PATH` before falling back to extension gemset.