### PR TITLE
Change outline captures from `@name` to `@context.extra`

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -91,16 +91,16 @@
         (call
             method: (identifier) @name
             arguments: (argument_list . [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
+                    (string) @context.extra
+                    (simple_symbol) @context.extra
+                    (scope_resolution) @context.extra
+                    (constant) @context.extra
                     "," @context
                 ]* [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
+                    (string) @context.extra
+                    (simple_symbol) @context.extra
+                    (scope_resolution) @context.extra
+                    (constant) @context.extra
                 ]
             )
         ) @item
@@ -113,16 +113,16 @@
         (call
             method: (identifier) @name
             arguments: (argument_list . [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
+                    (string) @context.extra
+                    (simple_symbol) @context.extra
+                    (scope_resolution) @context.extra
+                    (constant) @context.extra
                     "," @context
                 ]* [
-                    (string) @name
-                    (simple_symbol) @name
-                    (scope_resolution) @name
-                    (constant) @name
+                    (string) @context.extra
+                    (simple_symbol) @context.extra
+                    (scope_resolution) @context.extra
+                    (constant) @context.extra
                 ]
             )
         ) @item


### PR DESCRIPTION
Change all argument captures from `@name` to `@context.extra` in both call patterns to properly categorize these elements as contextual information rather than names to avoid capturing them for `ZED_SYMBOL` variable. This variable is used for running tests.

Sample code:

```ruby
class CategoryTest < ActiveSupport::TestCase
  class Foo
    include Bar
    belongs_to :foo
    has_many :whatever
    alias_method :a, :b
  end

  class Foo
    include Bar
    belongs_to :foo
    has_many :whatever
    alias_method :a, :b
  end

  module Foo
    include Bar
    belongs_to :foo
    has_many :whatever
    alias_method :a, :b
  end

  class Foo
    private
    important!
  end

  module Foo
    private
    important!
  end

  test "the truth" do
    assert true
  end
end
```

The outline is identical to the current behavior:

```
CategoryTest
└── Foo (class)
    ├── include Bar
    ├── belongs_to :foo
    ├── has_many :whatever
    └── alias_method :a, :b
└── Foo (class)
    ├── include Bar
    ├── belongs_to :foo
    ├── has_many :whatever
    └── alias_method :a, :b
└── Foo (module)
    ├── include Bar
    ├── belongs_to :foo
    ├── has_many :whatever
    └── alias_method :a, :b
└── Foo (class)
    ├── private
    └── important!
└── Foo (module)
    ├── private
    └── important!
└── test "the truth"
```

## Screenshots

|before|after|
|-----|------|
|![before](https://github.com/user-attachments/assets/39c90363-b1cb-4817-93e5-e448d47aa497)|![after](https://github.com/user-attachments/assets/89259f07-3613-410b-bd70-a815355ec3ea)|

Fixes https://github.com/zed-extensions/ruby/issues/92

