### PR TITLE
Expose `runnables` captures

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -17,7 +17,7 @@
 (
   (call
     method: (identifier) @run (#eq? @run "test")
-    arguments: (argument_list (string (string_content) @_name))
+    arguments: (argument_list (string (string_content) @name))
   ) @_ruby-test
   (#set! tag ruby-test)
 )
@@ -42,7 +42,7 @@
 (
   (call
     method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify")
-      arguments: (argument_list . (_) @_name)
+    arguments: (argument_list . (_) @name)
   ) @_ruby-test
   (#set! tag ruby-test)
 )
@@ -51,7 +51,7 @@
 (
   (call
     method: (identifier) @run (#any-of? @run "it" "its" "specify")
-    block: (_) @_name
+    block: (_) @name
     !arguments
   ) @_ruby-test
   (#set! tag ruby-test)


### PR DESCRIPTION
Exposing `runnables` captures makes them
available as Zed template variables. Each capture
is mapped to a Zed variable in the format:

```
ZED_CUSTOM_$(capture_name)
```

For example, consider this query:

```
(
  (call method: (identifier) @name)
)
```

This exposes the `@name` capture,
which can then be referenced in Zed templates as:

```
$ZED_CUSTOM_name
```

Key notes:

- Case Sensitivity: The syntax is case-sensitive. Ensure matches between capture names (e.g., `@name`) and variable references (e.g., `$ZED_CUSTOM_name`).
- Underscores: Captures prefixed with underscores (e.g., `@_ruby-test`) are not mapped to Zed variables.