### PR TITLE
Add `@RUBY_TEST_NAME` capture for test nodes

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -17,8 +17,8 @@
 (
   (call
     method: (identifier) @run (#eq? @run "test")
-    arguments: (argument_list (string (string_content) @name))
   ) @_ruby-test
+    arguments: (argument_list (string (string_content) @name @RUBY_TEST_NAME))
   (#set! tag ruby-test)
 )
 
@@ -42,8 +42,8 @@
 (
   (call
     method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify")
-    arguments: (argument_list . (_) @name)
   ) @_ruby-test
+    arguments: (argument_list . (_) @name @RUBY_TEST_NAME)
   (#set! tag ruby-test)
 )
 
@@ -51,7 +51,7 @@
 (
   (call
     method: (identifier) @run (#any-of? @run "it" "its" "specify")
-    block: (_) @name
+    block: (_) @name @RUBY_TEST_NAME
     !arguments
   ) @_ruby-test
   (#set! tag ruby-test)


### PR DESCRIPTION
Reordered and added `@RUBY_TEST_NAME` capture to test method arguments and blocks to provide explicit test name references for:
- test method with string argument
- describe/context/it/its/specify methods with arguments
- it/its/specify methods with blocks without arguments

This capture can be references in Zed tasks via `ZED_CUSTOM_RUBY_TEST_NAME` variable. For example, to run a single Minitest properly we need to define the following Zed task:

```json
  {
    "label": "test $ZED_RELATIVE_FILE -n /$ZED_CUSTOM_RUBY_TEST_NAME/",
    "command": "bin/rails",
    "args": [
      "test",
      "$ZED_RELATIVE_FILE",
      "-n",
      "/$ZED_CUSTOM_RUBY_TEST_NAME/"
    ],
    "tags": ["ruby-test"]
  }
```