### PR TITLE
Update GitHub Actions to use wasm32-wasip2 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          target: wasm32-wasip1
+          target: wasm32-wasip2
           override: true
           components: rustfmt, clippy
       - name: Lint (clippy)
@@ -45,14 +45,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.86
-          target: wasm32-wasip1
+          toolchain: 1.87
+          target: wasm32-wasip2
           override: true
       - name: Build extension
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target wasm32-wasip1 --all-features
+          args: --target wasm32-wasip2 --all-features
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
       - name: Test with latest nextest release


### PR DESCRIPTION
Update ci.yml to use `wasm32-wasip2` target

- Upgrade WASI target from wasip1 to wasip2 in all build configurations
- Update Rust toolchain from 1.86 to 1.87 in build job
- Ensure all cargo build commands use the new target
 
See [this pull request](https://github.com/zed-industries/zed/pull/30953) for more information.