### PR TITLE
ruby: Update tasks format

### DIFF
--- a/languages/ruby/tasks.json
+++ b/languages/ruby/tasks.json
@@ -1,14 +1,17 @@
 [
   {
     "label": "bundle exec rake",
-    "command": "bundle exec rake"
+    "command": "bundle",
+    "args": ["exec", "rake"]
   },
   {
     "label": "bundle install",
-    "command": "bundle install"
+    "command": "bundle",
+    "args": ["install"]
   },
   {
     "label": "Evaluate selected Ruby code",
-    "command": "ruby -e '$ZED_SELECTED_TEXT'"
+    "command": "ruby",
+    "args": ["-e", "$ZED_SELECTED_TEXT"]
   }
 ]


### PR DESCRIPTION
Split single command strings into command + args
to avoid things like https://github.com/zed-industries/zed/issues/31554