### PR TITLE
Adds .irbrc to language config

### DIFF
--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -17,6 +17,7 @@ path_suffixes = [
     "builder",
     "gemspec",
     "thor",
+    "irbrc",
     "pryrc",
     "simplecov",
     "Steepfile",


### PR DESCRIPTION
IRB configurations files where not registered as Ruby 
<img width="724" alt="image" src="https://github.com/user-attachments/assets/4408483c-f108-4564-bf8a-e53be94c781e" />

This PR registers it
<img width="718" alt="image" src="https://github.com/user-attachments/assets/2f414819-91a9-4c25-a49c-07dea51ed485" />
