### PR TITLE
feat: add sorbet Ruby LSP server option

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -22,6 +22,10 @@ languages = ["Ruby"]
 name = "Steep"
 languages = ["Ruby"]
 
+[language_servers.sorbet]
+name = "Sorbet"
+languages = ["Ruby"]
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "71bd32fb7607035768799732addba884a37a6210"

--- a/src/language_servers/mod.rs
+++ b/src/language_servers/mod.rs
@@ -2,10 +2,12 @@ mod language_server;
 mod rubocop;
 mod ruby_lsp;
 mod solargraph;
+mod sorbet;
 mod steep;
 
 pub use language_server::LanguageServer;
 pub use rubocop::*;
 pub use ruby_lsp::*;
 pub use solargraph::*;
+pub use sorbet::*;
 pub use steep::*;

--- a/src/language_servers/sorbet.rs
+++ b/src/language_servers/sorbet.rs
@@ -1,4 +1,4 @@
-use super::LanguageServer;
+use super::{language_server::WorktreeLike, LanguageServer};
 
 pub struct Sorbet {}
 
@@ -7,15 +7,36 @@ impl LanguageServer for Sorbet {
     const EXECUTABLE_NAME: &str = "srb";
     const GEM_NAME: &str = "sorbet";
 
-    fn get_executable_args() -> Vec<String> {
-        [
-            "tc",
-            "--lsp",
-            "--enable-experimental-lsp-document-highlight",
-        ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
+    fn get_executable_args<T: WorktreeLike>(&self, worktree: &T) -> Vec<String> {
+        let binary_settings = worktree
+            .lsp_binary_settings(Self::SERVER_ID)
+            .unwrap_or_default();
+
+        let default_args = vec![
+            "tc".to_string(),
+            "--lsp".to_string(),
+            "--enable-experimental-lsp-document-highlight".to_string(),
+        ];
+
+        // test if sorbet/config is present
+        match worktree.read_text_file("sorbet/config") {
+            Ok(_) => {
+                // Config file exists, prefer custom arguments if available.
+                binary_settings
+                    .and_then(|bs| bs.arguments)
+                    .unwrap_or(default_args)
+            }
+            Err(_) => {
+                // gross, but avoid sorbet errors in a non-sorbet
+                // environment by using an empty config
+                vec![
+                    "tc".to_string(),
+                    "--lsp".to_string(),
+                    "--dir".to_string(),
+                    "./".to_string(),
+                ]
+            }
+        }
     }
 }
 
@@ -27,7 +48,10 @@ impl Sorbet {
 
 #[cfg(test)]
 mod tests {
-    use crate::language_servers::{LanguageServer, Sorbet};
+    use crate::language_servers::{
+        language_server::{FakeWorktree, LspBinarySettings},
+        LanguageServer, Sorbet,
+    };
 
     #[test]
     fn test_server_id() {
@@ -40,14 +64,92 @@ mod tests {
     }
 
     #[test]
-    fn test_executable_args() {
-        assert_eq!(
-            Sorbet::get_executable_args(),
-            vec![
-                "tc",
-                "--lsp",
-                "--enable-experimental-lsp-document-highlight"
-            ]
+    fn test_executable_args_no_config_file() {
+        let sorbet = Sorbet::new();
+        let mut fake_worktree = FakeWorktree::new("/path/to/project".to_string());
+
+        fake_worktree.add_file(
+            "sorbet/config".to_string(),
+            Err("File not found".to_string()),
         );
+        fake_worktree.add_lsp_binary_setting(Sorbet::SERVER_ID.to_string(), Ok(None));
+
+        let expected_args_no_config = vec![
+            "tc".to_string(),
+            "--lsp".to_string(),
+            "--dir".to_string(),
+            "./".to_string(),
+        ];
+        assert_eq!(
+            sorbet.get_executable_args(&fake_worktree),
+            expected_args_no_config,
+            "Should use fallback arguments when sorbet/config is not found"
+        );
+    }
+
+    #[test]
+    fn test_executable_args_with_config_and_custom_settings() {
+        let sorbet = Sorbet::new();
+        let mut fake_worktree = FakeWorktree::new("/path/to/project".to_string());
+
+        fake_worktree.add_file("sorbet/config".to_string(), Ok("--dir\n.".to_string()));
+
+        let custom_args = vec!["--custom-arg1".to_string(), "value1".to_string()];
+        fake_worktree.add_lsp_binary_setting(
+            Sorbet::SERVER_ID.to_string(),
+            Ok(Some(LspBinarySettings {
+                path: None,
+                arguments: Some(custom_args.clone()),
+            })),
+        );
+
+        assert_eq!(
+            sorbet.get_executable_args(&fake_worktree),
+            custom_args,
+            "Should use custom arguments when config and settings are present"
+        );
+    }
+
+    #[test]
+    fn test_executable_args_with_config_no_custom_settings() {
+        let sorbet = Sorbet::new();
+        let mut fake_worktree = FakeWorktree::new("/path/to/project".to_string());
+
+        fake_worktree.add_file("sorbet/config".to_string(), Ok("--dir\n.".to_string()));
+        fake_worktree.add_lsp_binary_setting(Sorbet::SERVER_ID.to_string(), Ok(None));
+
+        let expected_default_args = vec![
+            "tc".to_string(),
+            "--lsp".to_string(),
+            "--enable-experimental-lsp-document-highlight".to_string(),
+        ];
+        assert_eq!(
+            sorbet.get_executable_args(&fake_worktree),
+            expected_default_args,
+            "Should use default arguments when config is present but no custom settings"
+        );
+    }
+
+    #[test]
+    fn test_executable_args_with_config_lsp_settings_is_empty_struct() {
+        let sorbet = Sorbet::new();
+        let mut fake_worktree = FakeWorktree::new("/path/to/project".to_string());
+
+        fake_worktree.add_file("sorbet/config".to_string(), Ok("--dir\n.".to_string()));
+        fake_worktree.add_lsp_binary_setting(
+            Sorbet::SERVER_ID.to_string(),
+            Ok(Some(LspBinarySettings::default())),
+        );
+
+        let expected_default_args = vec![
+            "tc".to_string(),
+            "--lsp".to_string(),
+            "--enable-experimental-lsp-document-highlight".to_string(),
+        ];
+        assert_eq!(
+                sorbet.get_executable_args(&fake_worktree),
+                expected_default_args,
+                "Should use default arguments when config is present and LSP settings have no arguments"
+            );
     }
 }

--- a/src/language_servers/sorbet.rs
+++ b/src/language_servers/sorbet.rs
@@ -1,0 +1,53 @@
+use super::LanguageServer;
+
+pub struct Sorbet {}
+
+impl LanguageServer for Sorbet {
+    const SERVER_ID: &str = "sorbet";
+    const EXECUTABLE_NAME: &str = "srb";
+    const GEM_NAME: &str = "sorbet";
+
+    fn get_executable_args() -> Vec<String> {
+        [
+            "tc",
+            "--lsp",
+            "--enable-experimental-lsp-document-highlight",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+}
+
+impl Sorbet {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::language_servers::{LanguageServer, Sorbet};
+
+    #[test]
+    fn test_server_id() {
+        assert_eq!(Sorbet::SERVER_ID, "sorbet");
+    }
+
+    #[test]
+    fn test_executable_name() {
+        assert_eq!(Sorbet::EXECUTABLE_NAME, "srb");
+    }
+
+    #[test]
+    fn test_executable_args() {
+        assert_eq!(
+            Sorbet::get_executable_args(),
+            vec![
+                "tc",
+                "--lsp",
+                "--enable-experimental-lsp-document-highlight"
+            ]
+        );
+    }
+}

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -3,7 +3,7 @@ mod command_executor;
 mod gemset;
 mod language_servers;
 
-use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph, Steep};
+use language_servers::{LanguageServer, Rubocop, RubyLsp, Solargraph, Sorbet, Steep};
 use zed_extension_api::{self as zed};
 
 #[derive(Default)]
@@ -11,6 +11,7 @@ struct RubyExtension {
     solargraph: Option<Solargraph>,
     ruby_lsp: Option<RubyLsp>,
     rubocop: Option<Rubocop>,
+    sorbet: Option<Sorbet>,
     steep: Option<Steep>,
 }
 
@@ -36,6 +37,10 @@ impl zed::Extension for RubyExtension {
             Rubocop::SERVER_ID => {
                 let rubocop = self.rubocop.get_or_insert_with(Rubocop::new);
                 rubocop.language_server_command(language_server_id, worktree)
+            }
+            Sorbet::SERVER_ID => {
+                let sorbet = self.sorbet.get_or_insert_with(Sorbet::new);
+                sorbet.language_server_command(language_server_id, worktree)
             }
             Steep::SERVER_ID => {
                 let steep = self.steep.get_or_insert_with(Steep::new);


### PR DESCRIPTION
Redo for #9 (unable to reopen after force-pushing to the branch for the original PR).

This adds Sorbet's LSP as an additional Ruby language server option and would take precedent over https://github.com/notchairmk/zed-sorbet.

In it's current state issues like notchairmk/zed-sorbet#6 will still be present. In addition, without `get_executable_args` being worktree-aware (and the extension being able to supply default args) the sorbet binary for a repo missing config at `sorbet/config` will fail to initiate. The workaround in zed-sorbet was to just supply empty config if that file is missing and allow for file-local errors.

These are the listed server capabilities
```json
{
  "textDocumentSync": 1,
  "hoverProvider": true,
  "completionProvider": {
    "triggerCharacters": [
      ".",
      ":",
      "@",
      "#"
    ]
  },
  "definitionProvider": true,
  "typeDefinitionProvider": true,
  "implementationProvider": true,
  "referencesProvider": true,
  "documentHighlightProvider": true,
  "documentSymbolProvider": true,
  "workspaceSymbolProvider": true,
  "codeActionProvider": {
    "codeActionKinds": [
      "quickfix",
      "source.fixAll.sorbet",
      "refactor.extract",
      "refactor.rewrite"
    ],
    "resolveProvider": true
  },
  "documentFormattingProvider": false,
  "renameProvider": {
    "prepareProvider": true
  }
}
```

<img width="802" alt="image" src="https://github.com/user-attachments/assets/b13e2cb0-b0f1-4d85-a51b-136435004263">
