### PR TITLE
ruby: Make `LanguageServer::get_executable_args` an instance method

### DIFF
--- a/src/language_servers/rubocop.rs
+++ b/src/language_servers/rubocop.rs
@@ -1,4 +1,5 @@
 use super::LanguageServer;
+use zed_extension_api::{self as zed};
 
 pub struct Rubocop {}
 
@@ -7,7 +8,7 @@ impl LanguageServer for Rubocop {
     const EXECUTABLE_NAME: &str = "rubocop";
     const GEM_NAME: &str = "rubocop";
 
-    fn get_executable_args() -> Vec<String> {
+    fn get_executable_args(&self, _worktree: &zed::Worktree) -> Vec<String> {
         vec!["--lsp".to_string()]
     }
 }

--- a/src/language_servers/solargraph.rs
+++ b/src/language_servers/solargraph.rs
@@ -9,7 +9,7 @@ impl LanguageServer for Solargraph {
     const EXECUTABLE_NAME: &str = "solargraph";
     const GEM_NAME: &str = "solargraph";
 
-    fn get_executable_args() -> Vec<String> {
+    fn get_executable_args(&self, _worktree: &zed::Worktree) -> Vec<String> {
         vec!["stdio".to_string()]
     }
 }

--- a/src/language_servers/steep.rs
+++ b/src/language_servers/steep.rs
@@ -8,7 +8,7 @@ impl LanguageServer for Steep {
     const EXECUTABLE_NAME: &str = "steep";
     const GEM_NAME: &str = "steep";
 
-    fn get_executable_args() -> Vec<String> {
+    fn get_executable_args(&self, _worktree: &zed::Worktree) -> Vec<String> {
         vec!["langserver".to_string()]
     }
 
@@ -39,7 +39,7 @@ impl LanguageServer for Steep {
 
         Ok(zed::Command {
             command: binary.path,
-            args: binary.args.unwrap_or(Self::get_executable_args()),
+            args: binary.args.unwrap_or(self.get_executable_args(worktree)),
             env: binary.env.unwrap_or_default(),
         })
     }
@@ -67,6 +67,7 @@ mod tests {
 
     #[test]
     fn test_executable_args() {
-        assert_eq!(Steep::get_executable_args(), vec!["langserver"]);
+        let test_server = Steep::new();
+        assert_eq!(test_server.get_executable_args(), vec!["langserver"]);
     }
 }


### PR DESCRIPTION
This change converts `get_executable_args` from a static to an instance
method, passing the worktree as an argument. This allows language servers
to customize arguments based on worktree context.

- Updated all implementations in `language_server.rs` to use instance method
- Modified implementation in rubocop, solargraph, and steep
- Updated all call sites to pass `worktree` parameter