### PR TITLE
fix(rdbg): use gemset-aware detection

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -6,7 +6,6 @@ schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"
 
-
 [language_servers.solargraph]
 name = "Solargraph"
 languages = ["Ruby"]
@@ -68,4 +67,4 @@ kind = "process:exec"
 command = "gem"
 args = ["update", "--norc", "*"]
 
-[debug_adapters.RDBG]
+[debug_adapters.rdbg]


### PR DESCRIPTION
Use gemset-aware detection for the `debug` gem that
provides the `rdbg` binary. Follow the same logic
we use for language servers:

1. `PATH`
2. Project gemset
3. Extension gemset
