### PR TITLE
Update `herb-language-server` executable path

### DIFF
--- a/src/language_servers/herb.rs
+++ b/src/language_servers/herb.rs
@@ -3,7 +3,7 @@ use std::{env, fs};
 use super::{language_server::WorktreeLike, LanguageServer};
 use zed_extension_api::{self as zed};
 
-const SERVER_PATH: &str = "node_modules/@herb-tools/language-server/dist/herb-language-server";
+const SERVER_PATH: &str = "node_modules/@herb-tools/language-server/bin/herb-language-server";
 const PACKAGE_NAME: &str = "@herb-tools/language-server";
 
 pub struct Herb {


### PR DESCRIPTION
Just a small pull request to update the `herb-language-server` executable as discussed on Discord.

In [v0.3.1](https://github.com/marcoroth/herb/releases/tag/v0.3.1) we changed the location of the `herb-language-server` executable from `./dist/herb-language-server` to `./bin/herb-language-server` to be more flexible if we would want to swap the implementation in the future.

This shouldn't be a breaking change since #110 hasn't been released yet.