### PR TITLE
chore: modernize string formatting with string interpolation

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -63,13 +63,12 @@ impl Bundler {
                 Some(status) => {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
                     Err(format!(
-                        "'bundle' command failed (status: {})\nError: {}",
-                        status, stderr
+                        "'bundle' command failed (status: {status})\nError: {stderr}",
                     ))
                 }
                 None => {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                    Err(format!("Failed to execute 'bundle' command: {}", stderr))
+                    Err(format!("Failed to execute 'bundle' command: {stderr}"))
                 }
             })
     }
@@ -156,7 +155,7 @@ mod tests {
         gem: &str,
     ) -> MockCommandExecutor {
         let mock = MockCommandExecutor::new();
-        let gemfile_path = format!("{}/Gemfile", dir);
+        let gemfile_path = format!("{dir}/Gemfile");
         mock.expect(
             "bundle",
             &["info", "--version", gem],

--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -24,7 +24,7 @@ impl Gemset {
 
         path.to_str()
             .map(ToString::to_string)
-            .ok_or_else(|| format!("Failed to convert path for '{}'", bin_name))
+            .ok_or_else(|| format!("Failed to convert path for '{bin_name}'"))
     }
 
     pub fn gem_path_env(&self) -> Vec<(String, String)> {
@@ -43,20 +43,20 @@ impl Gemset {
         ];
 
         self.execute_gem_command("install".into(), args)
-            .map_err(|e| format!("Failed to install gem '{}': {}", name, e))?;
+            .map_err(|e| format!("Failed to install gem '{name}': {e}"))?;
 
         Ok(())
     }
 
     pub fn update_gem(&self, name: &str) -> Result<(), String> {
         self.execute_gem_command("update".into(), vec![name.into()])
-            .map_err(|e| format!("Failed to update gem '{}': {}", name, e))?;
+            .map_err(|e| format!("Failed to update gem '{name}': {e}"))?;
         Ok(())
     }
 
     pub fn installed_gem_version(&self, name: &str) -> Result<Option<String>, String> {
-        let re = Regex::new(r"^(\S+) \((.+)\)$")
-            .map_err(|e| format!("Failed to compile regex: {}", e))?;
+        let re =
+            Regex::new(r"^(\S+) \((.+)\)$").map_err(|e| format!("Failed to compile regex: {e}"))?;
 
         let args = vec!["--exact".to_string(), name.into()];
         let output_str = self.execute_gem_command("list".into(), args)?;
@@ -100,13 +100,12 @@ impl Gemset {
                 Some(status) => {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
                     Err(format!(
-                        "Gem command failed (status: {})\nError: {}",
-                        status, stderr
+                        "Gem command failed (status: {status})\nError: {stderr}",
                     ))
                 }
                 None => {
                     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                    Err(format!("Failed to execute gem command: {}", stderr))
+                    Err(format!("Failed to execute gem command: {stderr}"))
                 }
             })
     }

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -97,7 +97,7 @@ impl WorktreeLike for FakeWorktree {
         self.files
             .get(path)
             .cloned()
-            .unwrap_or_else(|| Err(format!("File not found in mock: {}", path)))
+            .unwrap_or_else(|| Err(format!("File not found in mock: {path}")))
     }
 
     fn lsp_binary_settings(&self, server_id: &str) -> Result<Option<LspBinarySettings>, String> {
@@ -212,7 +212,7 @@ pub trait LanguageServer {
         worktree: &zed::Worktree,
     ) -> zed::Result<LanguageServerBinary> {
         let gem_home = std::env::current_dir()
-            .map_err(|e| format!("Failed to get extension directory: {}", e))?
+            .map_err(|e| format!("Failed to get extension directory: {e}"))?
             .to_string_lossy()
             .to_string();
 


### PR DESCRIPTION
This PR updates string formatting across multiple files to use Rust's
string interpolation syntax with named variables instead of positional
formatting arguments. The changes include:

* Replacing `"{}", var` with `"{var}"` for cleaner, more readable code and to make `clippy` happy