### PR TITLE
fix(rdbg): remove `RUBY_DEBUG_OPEN` environment variable

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -201,11 +201,7 @@ impl zed::Extension for RubyExtension {
             arguments,
             connection: Some(connection),
             cwd: ruby_config.cwd,
-            envs: ruby_config
-                .env
-                .into_iter()
-                .chain(std::iter::once(("RUBY_DEBUG_OPEN".into(), "true".into())))
-                .collect(),
+            envs: ruby_config.env.into_iter().collect(),
             request_args: StartDebuggingRequestArguments {
                 configuration: configuration.to_string(),
                 request: StartDebuggingRequestArgumentsRequest::Launch,


### PR DESCRIPTION
We already pass `--open` env variable earlier.