### PR TITLE
Bump to v0.10.1

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.10.0"
+version = "0.10.1"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"


### PR DESCRIPTION
There was a bug in zed_extension_cli that prevented debug adapters in extensions from being successfully registered. zed_extension_cli has been fixed (https://github.com/zed-industries/extensions/pull/2927), but we need to bump the version of this and the Swift extension so they'll get rebuild and republished using the fixed CLI.

This version includes:

- https://github.com/zed-extensions/ruby/pull/119
- https://github.com/zed-extensions/ruby/pull/111
- https://github.com/zed-extensions/ruby/pull/113