### PR TITLE
Ensure cwd actually has a default

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.10.2"
+version = "0.10.1"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "ruby"
 name = "Ruby"
 description = "Ruby support."
-version = "0.10.1"
+version = "0.10.2"
 schema_version = 1
 authors = ["Vitaly Slobodin <vitaliy.slobodin@gmail.com>"]
 repository = "https://github.com/zed-extensions/ruby"

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -166,6 +166,11 @@ impl zed::Extension for RubyExtension {
         let mut connection = resolve_tcp_template(tcp_connection)?;
         let mut configuration: serde_json::Value = serde_json::from_str(&config.config)
             .map_err(|e| format!("`config` is not a valid JSON: {e}"))?;
+        if let Some(configuration) = configuration.as_object_mut() {
+            configuration
+                .entry("cwd")
+                .or_insert_with(|| worktree.root_path().into());
+        }
 
         let ruby_config: RubyDebugConfig = serde_json::from_value(configuration.clone())
             .map_err(|e| format!("`config` is not a valid rdbg config: {e}"))?;
@@ -213,11 +218,6 @@ impl zed::Extension for RubyExtension {
             }
         }
 
-        if let Some(configuration) = configuration.as_object_mut() {
-            configuration
-                .entry("cwd")
-                .or_insert_with(|| worktree.root_path().into());
-        }
         arguments.extend(ruby_config.args);
 
         if use_bundler {


### PR DESCRIPTION
Turns out, the default cwd was getting set on the JSON config after we had already deserialized it into a RubyDebugConfig. This meant there was not in fact a default cwd, so if a config failed to specify, the launch would fail with a cryptic:
>process exited before debugger could connect
This is because bundle/rdbg would immediately exit, as it was being run from the home directory, not the project's directory.

closes #126 