### PR TITLE
Add support for debug locators

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -74,3 +74,4 @@ command = "gem"
 args = ["update", "--norc", "*"]
 
 [debug_adapters.rdbg]
+[debug_locators.ruby]

--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -61,7 +61,7 @@ collapsed_placeholder = "# ..."
 tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 word_characters = ["?", "!"]
-debuggers = ["RDBG"]
+debuggers = ["rdbg"]
 
 [overrides.string]
 completion_query_characters = ["-", "."]

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -38,10 +38,6 @@ struct RubyDebugConfig {
     cwd: Option<String>,
 }
 
-const COMMON_RUBY_COMMANDS: [&str; 7] = [
-    "bundle", "rake", "rspec", "minitest", "test", "ruby", "rails",
-];
-
 impl zed::Extension for RubyExtension {
     fn new() -> Self {
         Self::default()
@@ -329,14 +325,7 @@ impl zed::Extension for RubyExtension {
         resolved_label: String,
         debug_adapter_name: String,
     ) -> Option<DebugScenario> {
-        if debug_adapter_name != "rdbg"
-            || locator_name != "ruby"
-            || !COMMON_RUBY_COMMANDS
-                .iter()
-                // Oftentimes, Ruby projects will have a `bin` directory with an
-                // executable, hence the contains check.
-                .any(|cmd| build_task.command.contains(cmd))
-        {
+        if debug_adapter_name != "rdbg" || locator_name != "ruby" {
             return None;
         }
 

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -222,12 +222,10 @@ impl zed::Extension for RubyExtension {
             }
         }
 
-        if let Some(configuration) = configuration.as_object_mut() {
-            configuration
-                .entry("cwd")
-                .or_insert_with(|| worktree.root_path().into());
+        if !arguments.contains(&"--command".to_string()) {
+            // Ensure that all arguments are passed after a "--", as required by rdbg.
+            arguments.push("--".into());
         }
-
         arguments.extend(ruby_config.args);
 
         if use_bundler {


### PR DESCRIPTION
Add support for the Zed's new [debug locator](https://zed.dev/docs/extensions/debugger-extensions#defining-debug-locators) extension API. With this, users can now easily debug Ruby tests within Zed directly from the gutter, with no additional configuration needed. It also lets them use `rdbg` to debug a task launched from the `Launch` modal.