### PR TITLE
Support Rake outlines

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -239,3 +239,77 @@
     )
   )
 )
+
+; Root rake namespace
+(program
+  (call
+    method: (identifier) @namespace @name (#any-of? @namespace "namespace")
+    arguments: (argument_list . [
+        (string) @name
+        (simple_symbol) @name
+      ]
+    )
+  ) @item
+)
+
+; Nested rake namespace
+(call
+  method: (identifier) @parent_namespace (#any-of? @parent_namespace "namespace")
+  arguments: (argument_list . [
+      (string)
+      (simple_symbol)
+    ]+
+  )
+  block: (_
+    (_
+      (call
+        method: (identifier) @namespace @name (#any-of? @namespace "namespace")
+        arguments: (argument_list . [
+            (string) @name
+            (simple_symbol) @name
+          ]
+        )
+      ) @item
+    )
+  )
+)
+
+; Root rake task
+(program
+  (call
+    method: (identifier) @task @name (#any-of? @task "task")
+    arguments: (argument_list . [
+        (string) @name
+        (simple_symbol) @name
+        (pair
+          key: (hash_key_symbol) @name
+        )
+      ]
+    )
+  ) @item
+)
+
+; Nested rake task
+(call
+  method: (identifier) @namespace (#any-of? @namespace "namespace")
+  arguments: (argument_list . [
+      (string)
+      (simple_symbol)
+    ]+
+  )
+  block: (_
+    (_
+      (call
+        method: (identifier) @task @name (#any-of? @task "task")
+        arguments: (argument_list . [
+            (string) @name
+            (simple_symbol) @name
+            (pair
+              key: (hash_key_symbol) @name
+            )
+          ]
+        )
+      ) @item
+    )
+  )
+)


### PR DESCRIPTION
Add support for rake tasks and namespaces in the outline.

Namespaces are supported when the first positional argument is either a literal string or a literal symbol and the namespace is either in another namespace block or at the root of the program.

Tasks are supported when the first positional argument is either a literal string or a literal symbol or there is a keyword argument with a literal symbol key. Tasks can be nested in namespaces or be at the root of the program.

Since TreeSitter’s query language doesn't support recursion, it is possible for false-positives. The nested queries only check that they are inside a namespace call’s block. They don’t care if there’s a line of namespaces all the way from the `program` node. I think this is reasonable though given the limitations.

<img width="1393" alt="Screenshot 2025-06-30 at 19 45 54" src="https://github.com/user-attachments/assets/d6d4b82e-5603-455e-a1ef-2781726172e2" />

