### PR TITLE
feat(ruby): add `gem uninstall` functionality

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -56,6 +56,11 @@ args = ["install", "--norc", "--no-user-install", "--no-format-executable", "--n
 [[capabilities]]
 kind = "process:exec"
 command = "gem"
+args = ["uninstall", "--norc", "*", "--version", "*"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "gem"
 args = ["list", "--norc", "--exact", "*"]
 
 [[capabilities]]

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -226,7 +226,7 @@ pub trait LanguageServer {
         );
 
         match gemset.installed_gem_version(Self::GEM_NAME) {
-            Ok(Some(_version)) => {
+            Ok(Some(version)) => {
                 if gemset
                     .is_outdated_gem(Self::GEM_NAME)
                     .map_err(|e| e.to_string())?
@@ -238,6 +238,10 @@ pub trait LanguageServer {
 
                     gemset
                         .update_gem(Self::GEM_NAME)
+                        .map_err(|e| e.to_string())?;
+
+                    gemset
+                        .uninstall_gem(Self::GEM_NAME, &version)
                         .map_err(|e| e.to_string())?;
                 }
 


### PR DESCRIPTION
In some cases, there could be scenarios where
gem dependencies can conflict. To avoid these
conflicts, we need to uninstall the old version
after updating it.

Closes https://github.com/zed-extensions/ruby/issues/132