### PR TITLE
fix(ruby-lsp): Disable `onTypeFormatting` feature

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -82,13 +82,18 @@ impl zed::Extension for RubyExtension {
         language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> zed::Result<Option<zed::serde_json::Value>> {
-        let initialization_options =
-            zed::settings::LspSettings::for_worktree(language_server_id.as_ref(), worktree)
-                .ok()
-                .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
-                .unwrap_or_default();
-
-        Ok(Some(zed::serde_json::json!(initialization_options)))
+        match language_server_id.as_ref() {
+            RubyLsp::SERVER_ID => {
+                let ruby = self.ruby_lsp.get_or_insert_with(RubyLsp::new);
+                ruby.language_server_initialization_options(language_server_id, worktree)
+            }
+            _ => Ok(Some(
+                zed::settings::LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+                    .ok()
+                    .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+                    .unwrap_or_default(),
+            )),
+        }
     }
 
     fn label_for_completion(


### PR DESCRIPTION
The Ruby LSP has an issue with Zed and
and the `onTypeFormatting` feature which adds
odd pipes (`|`) when typing code.
Until https://github.com/zed-extensions/ruby/issues/38 is fixed upstream, we can explicitly disable this feature if it's not enabled.

|before|after|
|------|-------------|
|![before](https://github.com/user-attachments/assets/141e9854-549d-4834-b54b-99131250aa0d)|![after](https://github.com/user-attachments/assets/80e2d042-5d10-4902-9e16-7786796a3d37)|

