### PR TITLE
refactor: replace String with PathBuf for path handling

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -1,9 +1,9 @@
 use crate::command_executor::CommandExecutor;
-use std::path::Path;
+use std::path::PathBuf;
 
 /// A simple wrapper around the `bundle` command.
 pub struct Bundler {
-    pub working_dir: String,
+    pub working_dir: PathBuf,
     command_executor: Box<dyn CommandExecutor>,
 }
 
@@ -13,7 +13,7 @@ impl Bundler {
     /// # Arguments
     /// * `working_dir` - The working directory where `bundle` commands should be executed.
     /// * `command_executor` - An executor for `bundle` commands.
-    pub fn new(working_dir: String, command_executor: Box<dyn CommandExecutor>) -> Self {
+    pub fn new(working_dir: PathBuf, command_executor: Box<dyn CommandExecutor>) -> Self {
         Bundler {
             working_dir,
             command_executor,
@@ -43,7 +43,7 @@ impl Bundler {
         args: &[&str],
         envs: &[(&str, &str)],
     ) -> Result<String, String> {
-        let bundle_gemfile_path = Path::new(&self.working_dir).join("Gemfile");
+        let bundle_gemfile_path = self.working_dir.join("Gemfile");
         let bundle_gemfile = bundle_gemfile_path
             .to_str()
             .ok_or_else(|| "Invalid path to Gemfile".to_string())?;

--- a/src/language_servers/herb.rs
+++ b/src/language_servers/herb.rs
@@ -41,7 +41,7 @@ impl Herb {
                     .unwrap()
                     .join(&server_path)
                     .to_string_lossy()
-                    .to_string(),
+                    .into_owned(),
                 "--stdio".to_string(),
             ],
             env: Default::default(),

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 
 use crate::{bundler::Bundler, command_executor::RealCommandExecutor, gemset::Gemset};
+use std::path::PathBuf;
 use zed_extension_api::{self as zed};
 
 #[derive(Clone, Debug)]
@@ -164,7 +165,10 @@ pub trait LanguageServer {
             return self.try_find_on_path_or_extension_gemset(language_server_id, worktree);
         }
 
-        let bundler = Bundler::new(worktree.root_path(), Box::new(RealCommandExecutor));
+        let bundler = Bundler::new(
+            PathBuf::from(worktree.root_path()),
+            Box::new(RealCommandExecutor),
+        );
         let shell_env = worktree.shell_env();
         let env_vars: Vec<(&str, &str)> = shell_env
             .iter()
@@ -218,7 +222,7 @@ pub trait LanguageServer {
             .to_string_lossy()
             .to_string();
 
-        let gemset = Gemset::new(gem_home.clone(), Box::new(RealCommandExecutor));
+        let gemset = Gemset::new(PathBuf::from(&gem_home), Box::new(RealCommandExecutor));
 
         zed::set_language_server_installation_status(
             language_server_id,


### PR DESCRIPTION
Convert string fields to `PathBuf` for improved type safety and optimize path handling throughout the codebase. This includes changing `Gemset.gem_home` and `Bundler.working_dir` from `String` to `PathBuf`, enhancing path operations in the debug adapter and HERB language server, updating all calling code to efficiently use `PathBuf::from()`, and removing unnecessary string conversions and clones.