### PR TITLE
fix(gemset): Preserve env vars

### DIFF
--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -25,7 +25,7 @@ impl Gemset {
             .ok_or_else(|| format!("Failed to convert path for '{bin_name}'"))
     }
 
-    pub fn gem_path_env(&self, envs: Option<&[(&str, &str)]>) -> Vec<(String, String)> {
+    pub fn env(&self, envs: Option<&[(&str, &str)]>) -> Vec<(String, String)> {
         let mut env_map: std::collections::HashMap<String, String> = envs
             .unwrap_or(&[])
             .iter()
@@ -225,24 +225,24 @@ mod tests {
     }
 
     #[test]
-    fn test_gem_path_env() {
+    fn test_gem_env() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
             Box::new(MockGemCommandExecutor::new()),
         );
-        let env = gemset.gem_path_env(None);
+        let env = gemset.env(None);
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "GEM_PATH");
         assert_eq!(env[0].1, "/test/gem_home:$GEM_PATH");
     }
 
     #[test]
-    fn test_gem_path_env_with_env_vars() {
+    fn test_gem_env_with_env_vars() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
             Box::new(MockGemCommandExecutor::new()),
         );
-        let env = gemset.gem_path_env(Some(&[("GEM_HOME", "/home/user/.gem")]));
+        let env = gemset.env(Some(&[("GEM_HOME", "/home/user/.gem")]));
         assert_eq!(env.len(), 2);
 
         let env_map: std::collections::HashMap<String, String> = env.into_iter().collect();
@@ -251,12 +251,12 @@ mod tests {
     }
 
     #[test]
-    fn test_gem_path_env_with_env_vars_overwrite() {
+    fn test_gem_env_with_env_vars_overwrite() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
             Box::new(MockGemCommandExecutor::new()),
         );
-        let env = gemset.gem_path_env(Some(&[("GEM_PATH", "/home/user/.gem")]));
+        let env = gemset.env(Some(&[("GEM_PATH", "/home/user/.gem")]));
         assert_eq!(env.len(), 1);
 
         // GEM_PATH should be overwritten with our value

--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -25,11 +25,19 @@ impl Gemset {
             .ok_or_else(|| format!("Failed to convert path for '{bin_name}'"))
     }
 
-    pub fn gem_path_env(&self) -> Vec<(String, String)> {
-        vec![(
+    pub fn gem_path_env(&self, envs: Option<&[(&str, &str)]>) -> Vec<(String, String)> {
+        let mut env_map: std::collections::HashMap<String, String> = envs
+            .unwrap_or(&[])
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        env_map.insert(
             "GEM_PATH".to_string(),
             format!("{}:$GEM_PATH", self.gem_home.display()),
-        )]
+        );
+
+        env_map.into_iter().collect()
     }
 
     pub fn install_gem(&self, name: &str) -> Result<(), String> {
@@ -222,10 +230,38 @@ mod tests {
             TEST_GEM_HOME.into(),
             Box::new(MockGemCommandExecutor::new()),
         );
-        let env = gemset.gem_path_env();
+        let env = gemset.gem_path_env(None);
         assert_eq!(env.len(), 1);
         assert_eq!(env[0].0, "GEM_PATH");
         assert_eq!(env[0].1, "/test/gem_home:$GEM_PATH");
+    }
+
+    #[test]
+    fn test_gem_path_env_with_env_vars() {
+        let gemset = Gemset::new(
+            TEST_GEM_HOME.into(),
+            Box::new(MockGemCommandExecutor::new()),
+        );
+        let env = gemset.gem_path_env(Some(&[("GEM_HOME", "/home/user/.gem")]));
+        assert_eq!(env.len(), 2);
+
+        let env_map: std::collections::HashMap<String, String> = env.into_iter().collect();
+        assert_eq!(env_map.get("GEM_HOME").unwrap(), "/home/user/.gem");
+        assert_eq!(env_map.get("GEM_PATH").unwrap(), "/test/gem_home:$GEM_PATH");
+    }
+
+    #[test]
+    fn test_gem_path_env_with_env_vars_overwrite() {
+        let gemset = Gemset::new(
+            TEST_GEM_HOME.into(),
+            Box::new(MockGemCommandExecutor::new()),
+        );
+        let env = gemset.gem_path_env(Some(&[("GEM_PATH", "/home/user/.gem")]));
+        assert_eq!(env.len(), 1);
+
+        // GEM_PATH should be overwritten with our value
+        let env_map: std::collections::HashMap<String, String> = env.into_iter().collect();
+        assert_eq!(env_map.get("GEM_PATH").unwrap(), "/test/gem_home:$GEM_PATH");
     }
 
     #[test]

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -223,8 +223,8 @@ pub trait LanguageServer {
             .to_string();
 
         let gemset = Gemset::new(PathBuf::from(&gem_home), Box::new(RealCommandExecutor));
-        let shell_env = worktree.shell_env();
-        let env_vars: Vec<(&str, &str)> = shell_env
+        let worktree_shell_env = worktree.shell_env();
+        let worktree_shell_env_vars: Vec<(&str, &str)> = worktree_shell_env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))
             .collect();
@@ -261,7 +261,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.gem_path_env(Some(&env_vars))),
+                    env: Some(gemset.env(Some(&worktree_shell_env_vars))),
                 })
             }
             Ok(None) => {
@@ -281,7 +281,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.gem_path_env(Some(&env_vars))),
+                    env: Some(gemset.env(Some(&worktree_shell_env_vars))),
                 })
             }
             Err(e) => Err(e),

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -223,6 +223,11 @@ pub trait LanguageServer {
             .to_string();
 
         let gemset = Gemset::new(PathBuf::from(&gem_home), Box::new(RealCommandExecutor));
+        let shell_env = worktree.shell_env();
+        let env_vars: Vec<(&str, &str)> = shell_env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
 
         zed::set_language_server_installation_status(
             language_server_id,
@@ -256,7 +261,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.gem_path_env()),
+                    env: Some(gemset.gem_path_env(Some(&env_vars))),
                 })
             }
             Ok(None) => {
@@ -276,7 +281,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.gem_path_env()),
+                    env: Some(gemset.gem_path_env(Some(&env_vars))),
                 })
             }
             Err(e) => Err(e),


### PR DESCRIPTION
Pass `Worktree` shell environment variables to Ruby language servers by preserving `GEM_PATH` while allowing other variables to pass through. This should resolve some issues with remote development when the Ruby extension loses env variables.