### PR TITLE
fix(ruby): Expose `name` and `RUBY_TEST_NAME` captures on `test_`

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -25,7 +25,7 @@
 ; Methods that begin with test_
 (
   (method
-    name: (identifier) @run (#match? @run "^test_")
+    name: (identifier) @run @name @RUBY_TEST_NAME (#match? @run "^test_")
   ) @_ruby-test
   (#set! tag ruby-test)
 )


### PR DESCRIPTION
Expose `name` and `RUBY_TEST_NAME` captures on `test_` methods.

Given the following example:

```ruby
class TestApp < Minitest::Test
  def test_root_endpoint
    get "/"

    assert last_response.ok?
    assert_equal "application/json", last_response.content_type
  end
end
```

When the cursor is on line `  def test_root_endpoint` we need to expose `test_root_endpoint ` as `name` and `RUBY_TEST_NAME` to be able to run this test. This PR fixes that.