### PR TITLE
fix: Update language names to better represent embedded templates

### DIFF
--- a/languages/html-erb/config.toml
+++ b/languages/html-erb/config.toml
@@ -1,4 +1,4 @@
-name = "HTML/ERB"
+name = "HTML+ERB"
 grammar = "embedded_template"
 path_suffixes = ["html.erb"]
 autoclose_before = ">})"

--- a/languages/yaml-erb/config.toml
+++ b/languages/yaml-erb/config.toml
@@ -1,3 +1,3 @@
-name = "YAML/ERB"
+name = "YAML+ERB"
 grammar = "embedded_template"
 path_suffixes = ["yml.erb", "yaml.erb"]


### PR DESCRIPTION
This pull request updates the language names for `.html.erb` and `.yml.erb` files.

The previous names `HTML/ERB` and `YAML/ERB` used a forward slash which semantically suggests "either/or" rather than the actual relationship where ERB is embedded within HTML or YAML.

Using `HTML+ERB` and `YAML+ERB` with a plus sign better conveys that these are composite languages.