### PR TITLE
fix(ruby): resolve precedence issue with import keyword detection

### DIFF
--- a/languages/ruby/highlights.scm
+++ b/languages/ruby/highlights.scm
@@ -41,15 +41,13 @@
 
 ; Function calls
 
-(program
-  (call
-    (identifier) @keyword.import)
-  (#any-of? @keyword.import "require" "require_relative" "load"))
-
-"defined?" @function.method.builtin
-
 (call
   method: [(identifier) (constant)] @function.method)
+
+((identifier) @keyword.import
+ (#any-of? @keyword.import "require" "require_relative" "load"))
+
+"defined?" @function.method.builtin
 
 ; Function definitions
 


### PR DESCRIPTION
* Remove requirement for import keywords to be inside a program call
* Reorder the highlights to capture import keywords properly

Closes https://github.com/zed-extensions/ruby/issues/157