### PR TITLE
fix(rdbg): ensure we always have current dir

### DIFF
--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -243,7 +243,7 @@ impl zed::Extension for RubyExtension {
             command: Some(rdbg_path.to_string()),
             arguments,
             connection: Some(connection),
-            cwd: ruby_config.cwd,
+            cwd: ruby_config.cwd.or_else(|| Some(worktree.root_path())),
             envs: ruby_config.env.into_iter().collect(),
             request_args: StartDebuggingRequestArguments {
                 configuration: configuration.to_string(),


### PR DESCRIPTION
The `debug` gem requires the current directory
to be present, so if the debug configuration
does not include it, set it to the worktree root path.