### PR TITLE
Add 'feature' and 'scenario' to runnable methods for specs

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -41,7 +41,7 @@
 ; Examples
 (
   (call
-    method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify")
+    method: (identifier) @run (#any-of? @run "describe" "context" "it" "its" "specify" "feature" "scenario")
     arguments: (argument_list . (_) @name @RUBY_TEST_NAME)
   ) @_ruby-test
   (#set! tag ruby-test)


### PR DESCRIPTION
This allows the test running of specs that start with "feature" or "scenario".

In the current situation, we need to change the "scenario" tag to "it" to make it work. With this change, we no longer have to.