### PR TITLE
fix(gemset): add `cwd` to Gemset and set `RBENV_DIR` env var

### DIFF
--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -32,18 +32,17 @@ impl Gemset {
     }
 
     pub fn env(&self, envs: Option<&[(&str, &str)]>) -> Vec<(String, String)> {
-        let mut env_map: std::collections::HashMap<String, String> = envs
-            .unwrap_or(&[])
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-
-        env_map.insert(
+        let gem_path = (
             "GEM_PATH".to_string(),
             format!("{}:$GEM_PATH", self.gem_home.display()),
         );
 
-        env_map.into_iter().collect()
+        envs.unwrap_or(&[])
+            .iter()
+            .filter(|(k, _)| *k != "GEM_PATH")
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .chain(std::iter::once(gem_path))
+            .collect()
     }
 
     pub fn install_gem(&self, name: &str) -> Result<(), String> {

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -222,7 +222,11 @@ pub trait LanguageServer {
             .to_string_lossy()
             .to_string();
 
-        let gemset = Gemset::new(PathBuf::from(&gem_home), Box::new(RealCommandExecutor));
+        let gemset = Gemset::new(
+            PathBuf::from(&gem_home),
+            PathBuf::from(worktree.root_path()),
+            Box::new(RealCommandExecutor),
+        );
         let worktree_shell_env = worktree.shell_env();
         let worktree_shell_env_vars: Vec<(&str, &str)> = worktree_shell_env
             .iter()

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -154,7 +154,11 @@ impl zed::Extension for RubyExtension {
                 Err(_e) => {
                     let gem_home = std::env::current_dir()
                         .map_err(|e| format!("Failed to get extension directory: {e}"))?;
-                    let gemset = Gemset::new(gem_home, Box::new(RealCommandExecutor));
+                    let gemset = Gemset::new(
+                        gem_home,
+                        PathBuf::from(worktree.root_path()),
+                        Box::new(RealCommandExecutor),
+                    );
 
                     match gemset.install_gem("debug") {
                         Ok(_) => rdbg_path = gemset.gem_bin_path("rdbg")?,


### PR DESCRIPTION
## Description

This change adds a working dir field to the Gemset struct and passes this directory as the `RBENV_DIR` environment variable when executing gem commands. This ensures that `rbenv` uses the project's directory when resolving Ruby versions.

## Details

The Ruby extension uses `zed::Command` to invoke commands for managing its gems: updating, installing, and uninstalling. It seems that `zed::Command` does not set the working directory (`cwd`), which causes the invoked commands to run against the root directory. Below is the log of running `rbenv` with debug mode enabled via the `RBENV_DEBUG` environment variable:

```
+ '[' gem = ruby ']'
+ export RBENV_ROOT=/Users/rbenv/.rbenv
+ RBENV_ROOT=/Users/rbenv/.rbenv
+ exec /opt/homebrew/bin/rbenv exec gem install --norc --no-user-install --no-format-executable --no-document solargraph
+(/opt/homebrew/bin/rbenv:23): '[' -z /Users/rbenv/.rbenv ']'
+(/opt/homebrew/bin/rbenv:26): RBENV_ROOT=/Users/rbenv/.rbenv
+(/opt/homebrew/bin/rbenv:28): export RBENV_ROOT
+(/opt/homebrew/bin/rbenv:30): '[' -z '' ']'
+(/opt/homebrew/bin/rbenv:31): RBENV_DIR=/
+(/opt/homebrew/bin/rbenv:38): export RBENV_DIR
+(/opt/homebrew/bin/rbenv:40): '[' -n '' ']'
+(/opt/homebrew/bin/rbenv:40): export RBENV_ORIG_PATH=/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
+(/opt/homebrew/bin/rbenv:40): RBENV_ORIG_PATH=/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
+(/opt/homebrew/bin/rbenv:64): shopt -s nullglob
+(/opt/homebrew/bin/rbenv:67): rbenv_bin=/opt/homebrew/bin/rbenv
++(/opt/homebrew/bin/rbenv:68): canonicalize /opt/homebrew/bin/rbenv
++(/opt/homebrew/bin/rbenv:43): canonicalize(): local readlink resolved_path
+++(/opt/homebrew/bin/rbenv:44): canonicalize(): type -P greadlink
++(/opt/homebrew/bin/rbenv:44): canonicalize(): readlink=
+++(/opt/homebrew/bin/rbenv:44): canonicalize(): type -P readlink
++(/opt/homebrew/bin/rbenv:44): canonicalize(): readlink=/usr/bin/readlink
+++(/opt/homebrew/bin/rbenv:46): canonicalize(): /usr/bin/readlink -f /opt/homebrew/bin/rbenv
++(/opt/homebrew/bin/rbenv:46): canonicalize(): resolved_path=/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv
++(/opt/homebrew/bin/rbenv:47): canonicalize(): printf '%s\n' /opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv
++(/opt/homebrew/bin/rbenv:48): canonicalize(): return 0
+(/opt/homebrew/bin/rbenv:68): libexec_dir=/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv
+(/opt/homebrew/bin/rbenv:69): libexec_dir=/opt/homebrew/Cellar/rbenv/1.3.2/libexec
+(/opt/homebrew/bin/rbenv:78): export PATH=/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
+(/opt/homebrew/bin/rbenv:78): PATH=/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
+(/opt/homebrew/bin/rbenv:80): RBENV_HOOK_PATH=:/Users/rbenv/.rbenv/rbenv.d
+(/opt/homebrew/bin/rbenv:81): '[' '!' /opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d -ef /Users/rbenv/.rbenv/rbenv.d ']'
+(/opt/homebrew/bin/rbenv:83): RBENV_HOOK_PATH=:/Users/rbenv/.rbenv/rbenv.d:/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d
+(/opt/homebrew/bin/rbenv:85): RBENV_HOOK_PATH=:/Users/rbenv/.rbenv/rbenv.d:/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d:/usr/etc/rbenv.d:/opt/homebrew/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks
+(/opt/homebrew/bin/rbenv:89): RBENV_HOOK_PATH=/Users/rbenv/.rbenv/rbenv.d:/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d:/usr/etc/rbenv.d:/opt/homebrew/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks
+(/opt/homebrew/bin/rbenv:90): export RBENV_HOOK_PATH
+(/opt/homebrew/bin/rbenv:92): shopt -u nullglob
+(/opt/homebrew/bin/rbenv:95): command=exec
+(/opt/homebrew/bin/rbenv:96): case "$command" in
++(/opt/homebrew/bin/rbenv:109): type -P rbenv-exec
+(/opt/homebrew/bin/rbenv:109): command_path=/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec
+(/opt/homebrew/bin/rbenv:110): '[' -z /opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec ']'
+(/opt/homebrew/bin/rbenv:118): shift 1
+(/opt/homebrew/bin/rbenv:119): '[' gem = --help ']'
+(/opt/homebrew/bin/rbenv:126): exec /opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec gem install --norc --no-user-install --no-format-executable --no-document solargraph
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:20): '[' gem = --complete ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:24): rbenv-version-name
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:6): '[' -z '' ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:7): rbenv-version-file
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:13): target_dir=
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:28): '[' -n '' ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:31): find_local_version_file /
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:16): find_local_version_file(): local root=/
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:17): find_local_version_file(): [[ / =~ ^//[^/]*$ ]]
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:18): find_local_version_file(): '[' -s //.ruby-version ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:22): find_local_version_file(): '[' -n / ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:23): find_local_version_file(): root=
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:17): find_local_version_file(): [[ '' =~ ^//[^/]*$ ]]
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:18): find_local_version_file(): '[' -s /.ruby-version ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:22): find_local_version_file(): '[' -n '' ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:22): find_local_version_file(): break
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:25): find_local_version_file(): return 1
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:32): '[' / '!=' / ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file:33): echo /Users/rbenv/.rbenv/version
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:7): RBENV_VERSION_FILE=/Users/rbenv/.rbenv/version
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:8): rbenv-version-file-read /Users/rbenv/.rbenv/version
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file-read:6): VERSION_FILE=/Users/rbenv/.rbenv/version
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file-read:8): '[' -s /Users/rbenv/.rbenv/version ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-file-read:21): exit 1
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:8): true
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:8): RBENV_VERSION=
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:11): IFS='
'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:11): read -d '' -r -a scripts
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:11): rbenv-hooks version-name
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:9): '[' version-name = --complete ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:18): RBENV_COMMAND=version-name
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:19): '[' -z version-name ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): IFS=:
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): read -r -a hook_paths
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:26): shopt -s nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:32): shopt -u nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:11): true
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:17): '[' -z '' ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:18): echo system
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-version-name:19): exit
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:24): RBENV_VERSION=system
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:25): RBENV_COMMAND=gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:27): '[' -z gem ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:32): export RBENV_VERSION
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:33): rbenv-which gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:14): '[' gem = --complete ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:30): RBENV_COMMAND=gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:32): '[' -z gem ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:37): RBENV_VERSION=system
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:39): '[' system = system ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:40): remove_from_path /Users/rbenv/.rbenv/shims
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:19): remove_from_path(): local path_to_remove=/Users/rbenv/.rbenv/shims
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:20): remove_from_path(): local path_before
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:21): remove_from_path(): local result=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:22): remove_from_path(): '[' '' '!=' :/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin: ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:23): remove_from_path(): path_before=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:24): remove_from_path(): result=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:22): remove_from_path(): '[' :/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/Users/rbenv/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin: '!=' :/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin: ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:23): remove_from_path(): path_before=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:24): remove_from_path(): result=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:22): remove_from_path(): '[' :/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin: '!=' :/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin: ']'
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:26): remove_from_path(): result=:/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:27): remove_from_path(): echo /opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:40): PATH=/opt/homebrew/Cellar/rbenv/1.3.2/libexec:/opt/homebrew/opt/rustup/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:40): command -v gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:40): RBENV_COMMAND_PATH=/usr/bin/gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:46): [[ ! -x /usr/bin/gem ]]
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:50): IFS='
'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:50): read -d '' -r -a scripts
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:50): rbenv-hooks which
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:9): '[' which = --complete ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:18): RBENV_COMMAND=which
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:19): '[' -z which ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): IFS=:
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): read -r -a hook_paths
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:26): shopt -s nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:32): shopt -u nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:50): true
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:56): '[' -x /usr/bin/gem ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-which:57): echo /usr/bin/gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:33): RBENV_COMMAND_PATH=/usr/bin/gem
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:34): RBENV_BIN_PATH=/usr/bin
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:36): IFS='
'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:36): read -d '' -r -a scripts
++(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:36): rbenv-hooks exec
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:9): '[' exec = --complete ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:18): RBENV_COMMAND=exec
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:19): '[' -z exec ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): IFS=:
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:24): read -r -a hook_paths
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:26): shopt -s nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:28): for script in '"$path/$RBENV_COMMAND"/*.bash'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:29): echo /opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash.bash
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:27): for path in '"${hook_paths[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-hooks:32): shopt -u nullglob
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:36): true
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:37): for script in '"${scripts[@]}"'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:39): source /opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash.bash
++(/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash.bash:1): export RUBYLIB=/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash:
++(/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash.bash:1): RUBYLIB=/opt/homebrew/Cellar/rbenv/1.3.2/rbenv.d/exec/gem-rehash:
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:42): shift 1
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:43): '[' system '!=' system ']'
+(/opt/homebrew/Cellar/rbenv/1.3.2/libexec/rbenv-exec:46): exec -a gem /usr/bin/gem install --norc --no-user-install --no-format-executable --no-document solargraph
```

In the beginning, there is this line `+(/opt/homebrew/bin/rbenv:31): RBENV_DIR=/`  which indicates that the working directory is not set to the worktree and `rbenv` uses the root directory.

The possible solutions are:

- Set the system Ruby via `rbenv`
- Set `RBENV_DIR` in the Ruby extension before invoking any `gem` command. It's a hack, but it works.
- Check the `zed::Command` implementation to to see if the working directory can be changed to the worktree root.

Closes https://github.com/zed-extensions/ruby/issues/158
Closes https://github.com/zed-extensions/ruby/issues/152