### PR TITLE
feat(gemset): store and re-use Worktree shell env

### DIFF
--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -230,7 +230,6 @@ pub trait LanguageServer {
 
         let gemset = Gemset::new(
             PathBuf::from(&gem_home),
-            PathBuf::from(worktree.root_path()),
             Some(&worktree_shell_env_vars),
             Box::new(RealCommandExecutor),
         );

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -154,12 +154,8 @@ impl zed::Extension for RubyExtension {
                 Err(_e) => {
                     let gem_home = std::env::current_dir()
                         .map_err(|e| format!("Failed to get extension directory: {e}"))?;
-                    let gemset = Gemset::new(
-                        gem_home,
-                        PathBuf::from(worktree.root_path()),
-                        Some(&env_vars),
-                        Box::new(RealCommandExecutor),
-                    );
+                    let gemset =
+                        Gemset::new(gem_home, Some(&env_vars), Box::new(RealCommandExecutor));
 
                     match gemset.install_gem("debug") {
                         Ok(_) => rdbg_path = gemset.gem_bin_path("rdbg")?,


### PR DESCRIPTION
Refactor `Gemset` to store environment variables in the struct instead
of passing them to each method call. I think there was a change in upstream
how extensions commands inherit the process env. Without re-using Worktree
env the Ruby extension loses ability to use the correct Ruby version and other important variables like `PATH` or `RBENV_DIR`.

This also simplifies the API by:

* Adding `envs` field to the `Gemset` struct to store environment vars
* Modifying `new()` to accept optional environment variables
* Removing `envs` parameters from all public methods
* Merging stored envs with command-specific envs in `execute_gem_command`
* Updating all method calls and tests to use the new API pattern