### PR TITLE
Add outlines for schema.rb

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -313,3 +313,34 @@
     )
   )
 )
+; Single argument methods in schema.rb
+(call
+  receiver: (_ (scope_resolution) @_receiver (#eq? @_receiver "ActiveRecord::Schema"))
+  block: (_
+    (_
+      (call
+        method: (identifier) @context (#any-of? @context "create_enum" "create_schema" "create_table" "create_virtual_table" "enable_extension")
+        arguments: (argument_list . [
+          (string) @name
+        ])
+      ) @item
+    )
+  )
+)
+
+; Double argument methods in schema.rb
+(call
+  receiver: (_ (scope_resolution) @_receiver (#eq? @_receiver "ActiveRecord::Schema"))
+  block: (_
+    (_
+      (call
+        method: (identifier) @context (#eq? @context "add_foreign_key")
+        arguments: (argument_list . [
+            (string) @name
+        ] "," [
+            (string) @name
+        ])
+      ) @item
+    )
+  )
+)


### PR DESCRIPTION
This adds outlines for schema.rb files. 

I look up the structure of tables quite often, this makes jumping around this file a lot easier.

I _kinda_ vibe coded the syntax, so please suggest improvements if there are any 😇

<img width="3824" height="2474" alt="CleanShot 2025-09-17 at 10 35 13@2x" src="https://github.com/user-attachments/assets/56a13a2b-a62a-4e2b-993e-a90b293accfe" />
<img width="3824" height="2474" alt="CleanShot 2025-09-17 at 10 37 37@2x" src="https://github.com/user-attachments/assets/4617f4da-4530-4de4-b268-3acdd37564eb" />

