### PR TITLE
Add `(` and `)` to list of brackets

### DIFF
--- a/languages/ruby/brackets.scm
+++ b/languages/ruby/brackets.scm
@@ -1,3 +1,4 @@
+("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
 ("\"" @open "\"" @close)


### PR DESCRIPTION
Hello! I ran into an issue with one of the features of vim-mode; we eventually narrowed down the cause to this extension.

This should resolve https://github.com/zed-industries/zed/issues/38604

Let me know if this needs any edits.