### PR TITLE
fix(gems): improve environment handling and PATH resolution

### DIFF
--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -265,7 +265,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.env(Some(&worktree_shell_env_vars))),
+                    env: Some(gemset.env()),
                 })
             }
             Ok(None) => {
@@ -285,7 +285,7 @@ pub trait LanguageServer {
                 Ok(LanguageServerBinary {
                     path: executable_path,
                     args: Some(self.get_executable_args(worktree)),
-                    env: Some(gemset.env(Some(&worktree_shell_env_vars))),
+                    env: Some(gemset.env()),
                 })
             }
             Err(e) => Err(e),


### PR DESCRIPTION
The redesigned `Gemset` environment handling now properly prepends the
gem's bin directory to PATH and ensures `gem_home` is prioritized in
`GEM_PATH`:

1. If `GEM_PATH` is configured, we preserve it and prepend it with the path to the ext gems
2. If the Worktree shell does not have `GEM_PATH`, we set it to the path to the ext gems. 