### PR TITLE
Enable `editor::WrapSelectionsInTag` action in HTML+ERB files

### DIFF
--- a/languages/html-erb/config.toml
+++ b/languages/html-erb/config.toml
@@ -2,6 +2,7 @@ name = "HTML+ERB"
 grammar = "embedded_template"
 path_suffixes = ["html.erb"]
 autoclose_before = ">})"
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 brackets = [{ start = "<", end = ">", close = true, newline = true }]
 block_comment = ["<%#", "%>"]
 word_characters = ["?", "!"]


### PR DESCRIPTION
I believe this is what's needed to enable the `editor::WrapSelectionsInTag` action in HTML+ERB files. It worked on initial release, but I think at some point the implementation was generalized by letting languages specify `wrap_characters`, so currently it only works in pure HTML files.
