### PR TITLE
Syntax highlighting and outline support for empirical `fun` definitions

### DIFF
--- a/languages/ruby/highlights.scm
+++ b/languages/ruby/highlights.scm
@@ -214,3 +214,38 @@
 (interpolation
   "#{" @punctuation.special
   "}" @punctuation.special) @embedded
+
+
+; fun function definitions
+((call
+  method: (identifier) @methodName @keyword (#eq? @methodName "fun")
+  arguments: (argument_list
+    (pair
+      key: [
+        (call
+          method: (identifier) @function.method)
+        (identifier) @function.method
+        (constant) @function.method
+      ]
+      value: [
+        [
+          (call)
+          (identifier)
+          (constant)
+        ]
+      ]
+    )
+  )
+))
+
+; fun keywords (void and never)
+((call
+  method: (identifier) @keyword
+  arguments: (argument_list
+    (pair
+      value: (identifier) @constant.builtin
+    )
+  )
+)
+  (#eq? @keyword "fun")
+  (#any-of? @constant.builtin "void" "never"))

--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -344,3 +344,94 @@
     )
   )
 )
+
+; fun method signature definitions
+(call
+  method: (identifier) @methodName @context (#eq? @methodName "fun")
+  arguments: (argument_list
+    (pair
+      key: [
+        (call
+          receiver: (_) @context
+          operator: "." @context
+          method: (identifier) @name
+        )
+        (call
+          receiver: (_) @context
+          operator: "." @context
+          method: (identifier) @name
+          arguments: (argument_list) @name
+        )
+        (call
+          method: (identifier) @name
+        )
+        (call
+          method: (identifier) @name
+          arguments: (argument_list) @name
+        )
+        (identifier) @name
+      ]
+      "=>" @name
+      value: [
+        (call
+          method: (identifier) @name
+        )
+        (call
+          method: (identifier) @name
+          arguments: (argument_list) @name
+        )
+        (identifier) @name
+        (constant) @name
+      ]
+    )
+  )
+  block: (do_block)
+) @item
+
+; fun method signature definitions with modifier
+(call
+  method: (identifier) @context
+  arguments: (argument_list
+    (call
+      method: (identifier) @methodName @context (#eq? @methodName "fun")
+      arguments: (argument_list
+        (pair
+          key: [
+            (call
+              receiver: (_) @context
+              operator: "." @context
+              method: (identifier) @name
+            )
+            (call
+              receiver: (_) @context
+              operator: "." @context
+              method: (identifier) @name
+              arguments: (argument_list) @name
+            )
+            (call
+              method: (identifier) @name
+            )
+            (call
+              method: (identifier) @name
+              arguments: (argument_list) @name
+            )
+            (identifier) @name
+          ]
+          "=>" @name
+          value: [
+            (call
+              method: (identifier) @name
+            )
+            (call
+              method: (identifier) @name
+              arguments: (argument_list) @name
+            )
+            (identifier) @name
+            (constant) @name
+          ]
+        )
+      )
+    )
+  )
+  block: (do_block)
+) @item

--- a/languages/ruby/textobjects.scm
+++ b/languages/ruby/textobjects.scm
@@ -18,5 +18,11 @@
 (method
   body: (_)? @function.inside) @function.around
 
+(call
+  method: (identifier) @methodName (#eq? @methodName "fun")
+  block: (do_block
+    body: (_)? @function.inside
+  )) @function.around
+
 ; Comments
 (comment) @comment.inside


### PR DESCRIPTION
I realise this is a very unusual use of Ruby so completely understand if you’d rather not merge it here. I’ve written TreeSitter queries to support `fun` definitions from Empirical with syntax highlighting and outline support.

https://github.com/yippee-fun/empirical

These queries are so specific, it’s extremely unlikely that they would be triggered for anyone who isn’t using Empirical. You would need to have a call pattern like this in your code.

```ruby
fun foo => void do
end
```