### PR TITLE
Add support for `zed-comment`

### DIFF
--- a/languages/ruby/injections.scm
+++ b/languages/ruby/injections.scm
@@ -6,3 +6,6 @@
 ((regex
   (string_content) @content)
   (#set! "language" "regex"))
+
+((comment) @content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This pull request adds support for TODO comments via [`zed-comment`](https://github.com/thedadams/zed-comment).

<img width="1684" height="1410" alt="CleanShot 2025-11-08 at 01 53 14@2x" src="https://github.com/user-attachments/assets/22a96e51-6c84-4d6a-8cea-da8dd5f8444c" />

Feel free to close if you prefer to not have this in the Ruby extension, thank you!