### PR TITLE
Add `zed-comment` support for all `ERB` languages

### DIFF
--- a/languages/erb/injections.scm
+++ b/languages/erb/injections.scm
@@ -7,4 +7,5 @@
   (#set! "combined"))
 
 ((comment) @content
-  (#set! injection.language "comment"))
+  (#set! injection.language "comment")
+  (#set! "combined"))

--- a/languages/html-erb/injections.scm
+++ b/languages/html-erb/injections.scm
@@ -7,4 +7,5 @@
   (#set! "combined"))
 
 ((comment) @content
-  (#set! injection.language "comment"))
+  (#set! injection.language "comment")
+  (#set! "combined"))

--- a/languages/js-erb/injections.scm
+++ b/languages/js-erb/injections.scm
@@ -7,4 +7,5 @@
   (#set! "combined"))
 
 ((comment) @content
-  (#set! injection.language "comment"))
+  (#set! injection.language "comment")
+  (#set! "combined"))

--- a/languages/yaml-erb/injections.scm
+++ b/languages/yaml-erb/injections.scm
@@ -7,4 +7,5 @@
   (#set! "combined"))
 
 ((comment) @content
-  (#set! injection.language "comment"))
+  (#set! injection.language "comment")
+  (#set! "combined"))


### PR DESCRIPTION
Similar to #203, this adds [`zed-comment`](https://github.com/thedadams/zed-comment) support for all `ERB` languages.

<img width="862" height="570" alt="CleanShot 2025-11-08 at 17 41 28@2x" src="https://github.com/user-attachments/assets/833dc324-70ab-424a-991c-cadd6cd0eb14" />
