### PR TITLE
Introduce Kanayago LSP that provides real-time Ruby syntax checking

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -38,6 +38,10 @@ languages = ["Ruby"]
 name = "Herb"
 languages = ["HTML+ERB"]
 
+[language_servers.kanayago]
+name = "Kanayago"
+languages = ["Ruby"]
+
 [grammars.ruby]
 repository = "https://github.com/tree-sitter/tree-sitter-ruby"
 commit = "71bd32fb7607035768799732addba884a37a6210"

--- a/src/language_servers/kanayago.rs
+++ b/src/language_servers/kanayago.rs
@@ -1,0 +1,42 @@
+use super::{language_server::WorktreeLike, LanguageServer};
+
+pub struct Kanayago {}
+
+impl LanguageServer for Kanayago {
+    const SERVER_ID: &str = "kanayago";
+    const EXECUTABLE_NAME: &str = "kanayago";
+    const GEM_NAME: &str = "kanayago";
+
+    fn get_executable_args<T: WorktreeLike>(&self, _worktree: &T) -> Vec<String> {
+        vec!["--lsp".to_string()]
+    }
+}
+
+impl Kanayago {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::language_servers::{language_server::FakeWorktree, Kanayago, LanguageServer};
+
+    #[test]
+    fn test_server_id() {
+        assert_eq!(Kanayago::SERVER_ID, "kanayago");
+    }
+
+    #[test]
+    fn test_executable_name() {
+        assert_eq!(Kanayago::EXECUTABLE_NAME, "kanayago");
+    }
+
+    #[test]
+    fn test_executable_args() {
+        let kanayago = Kanayago::new();
+        let mock_worktree = FakeWorktree::new("/path/to/project".to_string());
+
+        assert_eq!(kanayago.get_executable_args(&mock_worktree), vec!["--lsp"]);
+    }
+}

--- a/src/language_servers/mod.rs
+++ b/src/language_servers/mod.rs
@@ -1,4 +1,5 @@
 mod herb;
+mod kanayago;
 mod language_server;
 mod rubocop;
 mod ruby_lsp;
@@ -7,6 +8,7 @@ mod sorbet;
 mod steep;
 
 pub use herb::Herb;
+pub use kanayago::Kanayago;
 pub use language_server::LanguageServer;
 pub use rubocop::Rubocop;
 pub use ruby_lsp::RubyLsp;

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -8,7 +8,9 @@ use std::{collections::HashMap, path::PathBuf};
 use bundler::Bundler;
 use command_executor::RealCommandExecutor;
 use gemset::{versioned_gem_home, Gemset};
-use language_servers::{Herb, LanguageServer, Rubocop, RubyLsp, Solargraph, Sorbet, Steep};
+use language_servers::{
+    Herb, Kanayago, LanguageServer, Rubocop, RubyLsp, Solargraph, Sorbet, Steep,
+};
 use serde::{Deserialize, Serialize};
 use zed_extension_api::{
     self as zed, resolve_tcp_template, DebugAdapterBinary, DebugConfig, DebugRequest,
@@ -24,6 +26,7 @@ struct RubyExtension {
     sorbet: Option<Sorbet>,
     steep: Option<Steep>,
     herb: Option<Herb>,
+    kanayago: Option<Kanayago>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -72,6 +75,10 @@ impl zed::Extension for RubyExtension {
             Herb::SERVER_ID => {
                 let herb = self.herb.get_or_insert_with(Herb::new);
                 herb.language_server_command(language_server_id, worktree)
+            }
+            Kanayago::SERVER_ID => {
+                let kanayago = self.kanayago.get_or_insert_with(Kanayago::new);
+                kanayago.language_server_command(language_server_id, worktree)
             }
             language_server_id => Err(format!("unknown language server: {language_server_id}")),
         }


### PR DESCRIPTION
Thank you for developing the Zed Ruby extension.

This PR adds support for [**Kanayago (金屋子)**](https://github.com/S-H-GAMELINKS/kanayago), a Ruby Language Server that provides real-time Ruby syntax checking.
This is my first contribution to the Zed project, so please let me know if there is anything I should change or improve.

## Summary

This PR adds the Kanayago extension to the Zed Ruby extensions repository.

### What is Kanayago?

Kanayago is a Ruby Language Server Protocol (LSP) implementation that provides:
- Real-time Ruby syntax checking based on Ruby’s `parse.y` AST
- AST-based Ruby code analysis
- A lightweight LSP implementation written entirely in Ruby

### Requirements

Users need to have the `kanayago` command available in their PATH:

```bash
gem install kanayago
```

### Demo

https://github.com/user-attachments/assets/f6b8edea-4799-4785-872e-b9b23ee17b84


### Repository

- Kanayago LSP: https://github.com/S-H-GAMELINKS/kanayago
