### PR TITLE
fix(ruby): Add more RSpec test methods

### DIFF
--- a/languages/ruby/outline.scm
+++ b/languages/ruby/outline.scm
@@ -143,7 +143,7 @@
 (program
   (call
     method: (identifier) @_run @name
-    (#any-of? @_run "describe" "context" "test" "it" "shared_examples")
+    (#any-of? @_run "describe" "context" "test" "it" "its" "specify" "example" "feature" "scenario" "shared_examples" "fdescribe" "fcontext" "fit" "fexample" "focus" "xdescribe" "xcontext" "xit" "xexample" "xspecify" "skip" "pending" "it_behaves_like" "it_should_behave_like" "include_context" "include_examples")
     arguments: (argument_list
       .
       [
@@ -163,7 +163,7 @@
 ; Nested test methods
 (call
   method: (identifier) @_ctx
-  (#any-of? @_ctx "describe" "context" "shared_examples")
+  (#any-of? @_ctx "describe" "context" "shared_examples" "fdescribe" "fcontext" "xdescribe" "xcontext")
   arguments: (argument_list
     .
     [
@@ -176,7 +176,7 @@
     (_
       (call
         method: (identifier) @_run @name
-        (#any-of? @_run "describe" "context" "test" "it" "shared_examples")
+        (#any-of? @_run "describe" "context" "test" "it" "its" "specify" "example" "feature" "scenario" "shared_examples" "fdescribe" "fcontext" "fit" "fexample" "focus" "xdescribe" "xcontext" "xit" "xexample" "xspecify" "skip" "pending" "it_behaves_like" "it_should_behave_like" "include_context" "include_examples")
         arguments: (argument_list
           .
           [
@@ -196,7 +196,7 @@
 ; RSpec one-liners
 (call
   method: (identifier) @_ctx
-  (#any-of? @_ctx "describe" "context" "shared_examples")
+  (#any-of? @_ctx "describe" "context" "shared_examples" "fdescribe" "fcontext" "xdescribe" "xcontext")
   arguments: (argument_list
     .
     [
@@ -209,7 +209,7 @@
     (_
       (call
         method: (identifier) @_run @name
-        (#any-of? @_run "it")
+        (#any-of? @_run "it" "its" "specify" "example" "fit" "fexample" "focus" "xit" "xexample" "xspecify" "skip" "pending")
         block: (block
           body: (block_body
             (call

--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -38,7 +38,7 @@
 ; Examples
 ((call
   method: (identifier) @run
-  (#any-of? @run "describe" "context" "it" "its" "specify" "feature" "scenario")
+  (#any-of? @run "describe" "context" "it" "its" "specify" "example" "feature" "scenario" "fdescribe" "fcontext" "fit" "fexample" "focus" "it_behaves_like" "it_should_behave_like" "include_context" "include_examples")
   arguments: (argument_list
     .
     (_) @name @RUBY_TEST_NAME)) @_ruby-test
@@ -47,7 +47,7 @@
 ; Examples (one-liner syntax)
 ((call
   method: (identifier) @run
-  (#any-of? @run "it" "its" "specify")
+  (#any-of? @run "it" "its" "specify" "example" "fit" "fexample" "focus")
   block: (_) @name @RUBY_TEST_NAME
   !arguments) @_ruby-test
   (#set! tag ruby-test))


### PR DESCRIPTION
Add missing RSpec test methods like `its`, `specify`, `example`, `feature`, `scenario`. Also, add support for focused methods like `fdescribe`, `fit` and so on.

Here is the test file (Claude-generated):

```ruby
# Test file for RSpec keywords in runnables and outline queries

RSpec.describe "Standard RSpec keywords" do
  context "when using basic keywords" do
    it "supports it keyword" do
      expect(true).to be true
    end

    example "supports example keyword" do
      expect(true).to be true
    end

    specify "supports specify keyword" do
      expect(true).to be true
    end
  end

  context "when using one-liner syntax" do
    subject { [ 1, 2, 3 ] }

    it { is_expected.to include(1) }
    its(:size) { is_expected.to eq(3) }
  end
end

# Focused examples for running specific tests
RSpec.fdescribe "Focused describe block" do
  fcontext "focused context" do
    fit "focused it example" do
      expect(1 + 1).to eq(2)
    end

    fexample "focused example keyword" do
      expect(true).to be true
    end

    focus "focused with focus keyword" do
      expect(true).to be true
    end
  end
end

# Skipped/pending examples
RSpec.xdescribe "Skipped describe block" do
  xcontext "skipped context" do
    xit "skipped it example" do
      raise "This should not run"
    end

    xexample "skipped example" do
      raise "This should not run"
    end

    xspecify "skipped specify" do
      raise "This should not run"
    end

    skip "explicitly skipped" do
      raise "This should not run"
    end

    pending "marked as pending" do
      raise "This is pending"
    end
  end
end

# Shared examples
RSpec.shared_examples "a collection" do
  it "has a size" do
    expect(subject.size).to be >= 0
  end

  it "is enumerable" do
    expect(subject).to respond_to(:each)
  end
end

RSpec.describe Array do
  subject { [ 1, 2, 3 ] }

  it_behaves_like "a collection"
  it_should_behave_like "a collection"
  include_examples "a collection"
end

RSpec.shared_context "with setup data" do
  let(:user) { double("User") }
  let(:admin) { double("Admin") }
end

RSpec.describe "Using shared context" do
  include_context "with setup data"

  it "has access to shared data" do
    expect(user).not_to be_nil
  end
end

# Capybara/feature specs
RSpec.feature "User authentication" do
  scenario "user logs in successfully" do
    expect(true).to be true
  end

  scenario "user logs out" do
    expect(true).to be true
  end
end

# Nested describe blocks
RSpec.describe "Calculator" do
  describe "#add" do
    context "with positive numbers" do
      it "returns the sum" do
        expect(1 + 1).to eq(2)
      end
    end

    context "with negative numbers" do
      example "returns the sum" do
        expect(-1 + -1).to eq(-2)
      end
    end
  end

  describe "#subtract" do
    specify "subtracts two numbers" do
      expect(5 - 3).to eq(2)
    end
  end
end

```

Some screeshots:

<img width="1100" height="1226" alt="CleanShot 2026-01-05 at 15 35 30@2x" src="https://github.com/user-attachments/assets/8cd94097-2bec-4ab4-94f5-397e227463a8" />
<img width="1100" height="824" alt="CleanShot 2026-01-05 at 15 35 26@2x" src="https://github.com/user-attachments/assets/8a3d0b8c-5a28-4404-a164-d9f94af5914d" />
<img width="1084" height="1136" alt="CleanShot 2026-01-05 at 15 35 20@2x" src="https://github.com/user-attachments/assets/9c83db73-b2b1-49e8-a4ce-f93771a1ff93" />


Skipped/pending test examples are visible in the outline panel but they are not runnable:

<img width="1798" height="980" alt="CleanShot 2026-01-05 at 15 35 43@2x" src="https://github.com/user-attachments/assets/ee443fa0-cd96-4b3f-b4fa-b8d68ab670b1" />


Fixes https://github.com/zed-extensions/ruby/issues/225