### PR TITLE
fix(ruby): Use `string_content` capture for Ruby test name extraction

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -38,10 +38,14 @@
 ; Examples
 ((call
   method: (identifier) @run
-  (#any-of? @run "describe" "context" "it" "its" "specify" "example" "feature" "scenario" "fdescribe" "fcontext" "fit" "fexample" "focus" "it_behaves_like" "it_should_behave_like" "include_context" "include_examples")
+  (#any-of? @run
+    "describe" "context" "it" "its" "specify" "example" "feature" "scenario" "fdescribe" "fcontext"
+    "fit" "fexample" "focus" "it_behaves_like" "it_should_behave_like" "include_context"
+    "include_examples")
   arguments: (argument_list
     .
-    (_) @name @RUBY_TEST_NAME)) @_ruby-test
+    (_
+      (string_content) @name @RUBY_TEST_NAME))) @_ruby-test
   (#set! tag ruby-test))
 
 ; Examples (one-liner syntax)


### PR DESCRIPTION
Given this Ruby file:

```ruby
require "test_helper"

class CategoryTest < ActiveSupport::TestCase
  context "validations" do
    should validate_presence_of(:name)
    should validate_length_of(:name).is_at_most(255)
    should validate_uniqueness_of(:name)

    should validate_presence_of(:slug)
    should validate_length_of(:slug).is_at_most(255)
    should validate_uniqueness_of(:slug)
  end
end

```

Attempting to run test called `"validations"` results in the following output:

```
# Running:

......

Finished in 0.196336s, 30.5599 runs/s, 30.5599 assertions/s.
6 runs, 6 assertions, 0 failures, 0 errors, 0 skips

⏵ Task `test test/models/category_test.rb -n ""validations""` finished successfully
⏵ Command: /opt/homebrew/bin/fish -i -c 'bin/rails'
```

With this fix:

```
# Running:

......

Finished in 0.212972s, 28.1727 runs/s, 28.1727 assertions/s.
6 runs, 6 assertions, 0 failures, 0 errors, 0 skips

⏵ Task `test test/models/category_test.rb -n "validations"` finished successfully
⏵ Command: /opt/homebrew/bin/fish -i -c 'bin/rails'
```

No changes but capturing the test name as a string without quotes gives more control over tests that, for example, use regular expressions in their names.

Closes https://github.com/zed-extensions/ruby/issues/222