### PR TITLE
feat(gemset): Install gems per Ruby version to avoid compat issues

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -80,5 +80,10 @@ kind = "process:exec"
 command = "gem"
 args = ["update", "--norc", "*"]
 
+[[capabilities]]
+kind = "process:exec"
+command = "ruby"
+args = ["--version"]
+
 [debug_adapters.rdbg]
 [debug_locators.ruby]

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use bundler::Bundler;
 use command_executor::RealCommandExecutor;
-use gemset::Gemset;
+use gemset::{versioned_gem_home, Gemset};
 use language_servers::{Herb, LanguageServer, Rubocop, RubyLsp, Solargraph, Sorbet, Steep};
 use serde::{Deserialize, Serialize};
 use zed_extension_api::{
@@ -143,8 +143,9 @@ impl zed::Extension for RubyExtension {
             } else if let Some(path) = worktree.which(&adapter_name) {
                 (path, Vec::new())
             } else {
-                let gem_home = std::env::current_dir()
+                let base_dir = std::env::current_dir()
                     .map_err(|e| format!("Failed to get extension directory: {e}"))?;
+                let gem_home = versioned_gem_home(&base_dir, &env_vars, &RealCommandExecutor)?;
                 let gemset = Gemset::new(gem_home, Some(&env_vars), Box::new(RealCommandExecutor));
                 gemset
                     .install_gem("debug")


### PR DESCRIPTION
When users switch Ruby versions (e.g., from 3.2 to 3.3), previously installed gems with native extensions can break due to ABI incompatibilities or something else. This also affects the same Ruby version compiled with different configurations or on different platforms.

This change introduces version-specific gem directories by hashing the output of `ruby --version`, which includes version, revision, and platform info. Gems are now installed to `gems/<hash>/` instead of the extension root, ensuring each Ruby environment gets its own isolated gem set.

Closes https://github.com/zed-extensions/ruby/issues/107