### PR TITLE
Fix runnable detection

### DIFF
--- a/languages/ruby/runnables.scm
+++ b/languages/ruby/runnables.scm
@@ -44,8 +44,15 @@
     "include_examples")
   arguments: (argument_list
     .
-    (_
-      (string_content) @name @RUBY_TEST_NAME))) @_ruby-test
+    [
+      (_
+        (string_content) @name @RUBY_TEST_NAME)
+      (constant) @name @RUBY_TEST_NAME
+      (scope_resolution) @name @RUBY_TEST_NAME
+      (simple_symbol) @name @RUBY_TEST_NAME
+      ; Catch-all to make sure we don't miss any cases (numbers, arrays, dynamically generated names, etc)
+      (_) @name @RUBY_TEST_NAME
+    ])) @_ruby-test
   (#set! tag ruby-test))
 
 ; Examples (one-liner syntax)


### PR DESCRIPTION
In #229 , we changed the runnable detection logic for it, describe, its, etc. to look inside of strings for their content so that we don't pass along their quotations to the command line. However, in doing so, tests that use modules, classes, or symbols were no longer being detected. Add back detection for those, and a catch-all to make sure we don't miss any other cases (which is what we had before).