### PR TITLE
improve auto indent

### DIFF
--- a/languages/ruby/config.toml
+++ b/languages/ruby/config.toml
@@ -59,6 +59,8 @@ brackets = [
 ]
 collapsed_placeholder = "# ..."
 tab_size = 2
+increase_indent_pattern = '(^\s*(module|class|def|if|elsif|else|unless|case|when|while|until|for|begin|rescue|ensure)\b|\bdo\s*(\|[^|]*\|)?\s*$)'
+decrease_indent_pattern = '^\s*(end|elsif|else|when|rescue|ensure)\b'
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 word_characters = ["?", "!"]
 debuggers = ["rdbg"]

--- a/languages/ruby/indents.scm
+++ b/languages/ruby/indents.scm
@@ -1,27 +1,37 @@
-(method
-  "end" @end) @indent
-
 (class
   "end" @end) @indent
 
 (module
   "end" @end) @indent
 
-(begin
+(method
   "end" @end) @indent
 
 (singleton_method
   "end" @end) @indent
 
+(if
+  "end" @end) @indent
+
+(unless
+  "end" @end) @indent
+
+(case
+  "end" @end) @indent
+
+(begin
+  "end" @end) @indent
+
 (do_block
   "end" @end) @indent
 
-[
-  (then)
-  (call)
-] @indent
+(do
+  "end" @end) @indent
 
 [
+  (else)
+  (elsif)
+  (when)
   (ensure)
   (rescue)
 ] @outdent


### PR DESCRIPTION
This PR improves auto indent behavior.

For instance, when typing `def my_func + ENTER`

We get :
```ruby
def my_func
  |  <--- cursor position
```