### PR TITLE
refactor: switch to `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "auditable-serde"
@@ -1112,6 +1112,7 @@ dependencies = [
 name = "zed_ruby"
 version = "0.16.5"
 dependencies = [
+ "anyhow",
  "insta",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ regex = "1.11.1"
 serde_json = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 zed_extension_api = "0.7.0"
+anyhow = "1.0.89"
 
 [dev-dependencies]
 tree-sitter = "0.25"

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -144,13 +144,16 @@ impl zed::Extension for RubyExtension {
                 (path, Vec::new())
             } else {
                 let base_dir = std::env::current_dir()
-                    .map_err(|e| format!("Failed to get extension directory: {e}"))?;
-                let gem_home = versioned_gem_home(&base_dir, &env_vars, &RealCommandExecutor)?;
+                    .map_err(|e| format!("Failed to get extension directory: {e:#}"))?;
+                let gem_home = versioned_gem_home(&base_dir, &env_vars, &RealCommandExecutor)
+                    .map_err(|e| format!("{:#}", e))?;
                 let gemset = Gemset::new(gem_home, Some(&env_vars), Box::new(RealCommandExecutor));
                 gemset
                     .install_gem("debug")
-                    .map_err(|e| format!("Failed to install debug gem: {e}"))?;
-                let rdbg = gemset.gem_bin_path("rdbg")?;
+                    .map_err(|e| format!("Failed to install debug gem: {e:#}"))?;
+                let rdbg = gemset
+                    .gem_bin_path("rdbg")
+                    .map_err(|e| format!("{:#}", e))?;
                 (rdbg, Vec::new())
             }
         };
@@ -162,7 +165,7 @@ impl zed::Extension for RubyExtension {
         });
         let mut connection = resolve_tcp_template(tcp_connection)?;
         let mut configuration: serde_json::Value = serde_json::from_str(&config.config)
-            .map_err(|e| format!("`config` is not a valid JSON: {e}"))?;
+            .map_err(|e| format!("`config` is not a valid JSON: {e:#}"))?;
         if let Some(configuration) = configuration.as_object_mut() {
             configuration
                 .entry("cwd")
@@ -170,7 +173,7 @@ impl zed::Extension for RubyExtension {
         }
 
         let ruby_config: RubyDebugConfig = serde_json::from_value(configuration.clone())
-            .map_err(|e| format!("`config` is not a valid rdbg config: {e}"))?;
+            .map_err(|e| format!("`config` is not a valid rdbg config: {e:#}"))?;
 
         if let Some(host) = ruby_config.env.get("RUBY_DEBUG_HOST") {
             connection.host = host


### PR DESCRIPTION
Replace string-based error handling with `anyhow` `Result` type throughout the extension code.
This provides more structured error handling with better context propagation and formatting.