### PR TITLE
chore: Add `brackers`, `indents`, `outline` to tree-sitter LS config

### DIFF
--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -9,6 +9,10 @@
     "yaml-erb": "embedded_template"
   },
   "valid_captures": {
+    "brackets": {
+      "open": "Captures opening brackets, braces, and quotes.",
+      "close": "Captures closing brackets, braces, and quotes."
+    },
     "highlights": {
       "attribute": "An attribute",
       "boolean": "A boolean value",
@@ -58,6 +62,17 @@
       "variable.parameter": "A function or method parameter",
       "variable.special": "A special variable",
       "variant": "A variant"
+    },
+    "indents": {
+      "end": "Captures closing brackets and braces.",
+      "indent": "Captures entire arrays and objects for indentation."
+    },
+    "outline": {
+      "name": "Captures the content of object keys.",
+      "item": "Captures the entire key-value pair.",
+      "context": "Captures elements that provide context for the outline item.",
+      "context.extra": "Captures additional contextual information for the outline item.",
+      "annotation": "Captures nodes that annotate outline item (doc comments, attributes, decorators)."
     },
     "runnables": {
       "name": "Captures the \"scripts\" key",


### PR DESCRIPTION
Add `brackers`, `indents`, `outline` to tree-sitter LS config