### PR TITLE
Highlight instance vars, method defs, and keyword params distinctly

### DIFF
--- a/languages/ruby/highlights.scm
+++ b/languages/ruby/highlights.scm
@@ -81,13 +81,13 @@
   name: [
     (identifier)
     (constant)
-  ] @function.method)
+  ] @function.method.definition)
 
 (singleton_method
   name: [
     (identifier)
     (constant)
-  ] @function.method)
+  ] @function.method.definition)
 
 (method_parameters
   [
@@ -98,7 +98,7 @@
       [
         name: (identifier)
         ":"
-      ] @variable.parameter)
+      ] @variable.parameter.keyword)
   ])
 
 (block_parameters
@@ -138,10 +138,9 @@
 
 (super) @variable.special
 
-[
-  (class_variable)
-  (instance_variable)
-] @variable.special
+(class_variable) @variable.special
+
+(instance_variable) @variable.special.instance
 
 ((call
   !receiver


### PR DESCRIPTION
### Why

Coming from VSCode/Cursor ecosystem, I really miss these semantic token modifiers:

| Construct | Current capture | Shares its color with |
|---|---|---|
| Instance variables (`@foo`) | `@variable.special` | `self`, `super`, class variables |
| Method definitions (`def foo`) | `@function.method` | every method **call** |
| Keyword params (`def m(foo:)`) | `@variable.parameter` | positional parameters |

These are exactly the distinctions many editors/themes expose (e.g. VS Code separates a method *declaration* from a method *call* via semantic token modifiers), but here the grammar collapses them, so the information needed to theme them is thrown away before it ever reaches the theme layer.

`self`, `super`, and class variables intentionally stay on `@variable.special`; method calls stay on `@function.method`; positional params stay on `@variable.parameter`.

### Backwards compatibility

This PR is purely **additive**: existing themes are unaffected, and theme authors gain three new opt-in targets.

### Consistency with existing conventions

The new names follow the dotted sub-scoping already used throughout this file.

### How a theme author opts in

```jsonc
// theme_overrides (or a theme's syntax map)
"syntax": {
  "variable.special.instance":  { "color": "#..." }, // @foo distinct from self/super
  "function.method.definition": { "color": "#..." }, // def name distinct from calls
  "variable.parameter.keyword": { "color": "#..." }  // kwargs distinct from positional
}
```

### Screenshots

#### Before

<img width="354" height="690" alt="Screenshot 2026-06-23 at 23 50 06" src="https://github.com/user-attachments/assets/0f72ba9e-b424-4191-841c-646cc41f771f" />

#### After

<img width="354" height="690" alt="Screenshot 2026-06-23 at 23 48 56" src="https://github.com/user-attachments/assets/f188764f-d360-4386-bd3c-4e92017cdc5d" />