### PR TITLE
Support strict locals highlighting in ERB files

### DIFF
--- a/languages/erb/injections.scm
+++ b/languages/erb/injections.scm
@@ -7,5 +7,10 @@
   (#set! "combined"))
 
 ((comment) @content
+  (#match? @content "^\\s*locals:\\s+\\(")
+  (#set! "language" "ruby"))
+
+((comment) @content
+  (#not-match? @content "^\\s*locals:\\s+\\(")
   (#set! injection.language "comment")
   (#set! "combined"))

--- a/languages/html-erb/injections.scm
+++ b/languages/html-erb/injections.scm
@@ -7,5 +7,10 @@
   (#set! "combined"))
 
 ((comment) @content
+  (#match? @content "^\\s*locals:\\s+\\(")
+  (#set! "language" "ruby"))
+
+((comment) @content
+  (#not-match? @content "^\\s*locals:\\s+\\(")
   (#set! injection.language "comment")
   (#set! "combined"))

--- a/languages/js-erb/injections.scm
+++ b/languages/js-erb/injections.scm
@@ -7,5 +7,10 @@
   (#set! "combined"))
 
 ((comment) @content
+  (#match? @content "^\\s*locals:\\s+\\(")
+  (#set! "language" "ruby"))
+
+((comment) @content
+  (#not-match? @content "^\\s*locals:\\s+\\(")
   (#set! injection.language "comment")
   (#set! "combined"))

--- a/languages/ruby/highlights.scm
+++ b/languages/ruby/highlights.scm
@@ -104,6 +104,28 @@
 (block_parameters
   (identifier) @variable.parameter)
 
+; ERB strict locals are injected as Ruby, but their parameter list is not a
+; valid standalone Ruby program. Match the parser's recovery shape so the
+; first required local and the remaining keyword locals are highlighted alike.
+((call
+  method: (identifier) @_locals
+  arguments: (argument_list
+    (parenthesized_statements
+      (call
+        method: (identifier) @variable.parameter.keyword))))
+  (#eq? @_locals "locals"))
+
+((call
+  method: (identifier) @_locals
+  arguments: (argument_list
+    (parenthesized_statements
+      (call
+        arguments: (argument_list
+          (pair
+            key: (hash_key_symbol) @variable.parameter.keyword))))))
+  (#eq? @_locals "locals")
+  (#not-eq? @variable.parameter.keyword ""))
+
 ; Identifiers
 ((identifier) @constant.builtin
   (#match? @constant.builtin "^__(FILE|LINE|ENCODING)__$"))

--- a/languages/yaml-erb/injections.scm
+++ b/languages/yaml-erb/injections.scm
@@ -7,5 +7,10 @@
   (#set! "combined"))
 
 ((comment) @content
+  (#match? @content "^\\s*locals:\\s+\\(")
+  (#set! "language" "ruby"))
+
+((comment) @content
+  (#not-match? @content "^\\s*locals:\\s+\\(")
   (#set! injection.language "comment")
   (#set! "combined"))

--- a/tests/erb.rs
+++ b/tests/erb.rs
@@ -8,3 +8,42 @@ fn injections() {
         "languages/erb/injections.scm",
     );
 }
+
+#[test]
+fn strict_locals_are_injected_as_ruby() {
+    let source = "<%# locals: (title:, subtitle: nil, **options) %>";
+    let query = std::fs::read_to_string("languages/erb/injections.scm").unwrap();
+    let captures = support::run_query(source, &query, "erb");
+
+    assert_eq!(captures.len(), 1);
+    assert_eq!(captures[0].name, "content");
+    assert_eq!(
+        captures[0].text,
+        " locals: (title:, subtitle: nil, **options) "
+    );
+}
+
+#[test]
+fn strict_locals_require_whitespace_before_parameters() {
+    let source = "<%# locals:(title:) %>";
+    let query = std::fs::read_to_string("languages/erb/injections.scm").unwrap();
+    let captures = support::run_query(source, &query, "erb");
+
+    assert_eq!(captures.len(), 1);
+    assert_eq!(captures[0].name, "content");
+    assert_eq!(captures[0].text, " locals:(title:) ");
+}
+
+#[test]
+fn strict_local_names_share_parameter_highlighting() {
+    let source = "locals: (title:, talks:, view_all_path: root_path, subtitle: nil)";
+    let query = std::fs::read_to_string("languages/ruby/highlights.scm").unwrap();
+    let captures = support::run_query(source, &query, "ruby");
+    let parameters: Vec<_> = captures
+        .iter()
+        .filter(|capture| capture.name == "variable.parameter.keyword")
+        .map(|capture| capture.text.as_str())
+        .collect();
+
+    assert_eq!(parameters, ["title", "talks", "view_all_path", "subtitle"]);
+}

--- a/tests/languages/erb/injections.erb
+++ b/tests/languages/erb/injections.erb
@@ -2,6 +2,8 @@ Hello <%= user.name %>
 
 <%# Embedded template comment %>
 
+<%# locals: (title:, subtitle: nil, **options) %>
+
 <% if admin? %>
   Welcome, <%= admin_name %>
 <% end %>

--- a/tests/languages/erb/snapshots/injections.snap
+++ b/tests/languages/erb/snapshots/injections.snap
@@ -24,25 +24,33 @@ expression: captures
   text: "\n\n"
 - name: content
   line: 5
+  column: 4
+  text: " locals: (title:, subtitle: nil, **options) "
+- name: content
+  line: 5
+  column: 50
+  text: "\n\n"
+- name: content
+  line: 7
   column: 3
   text: " if admin? "
 - name: content
-  line: 5
+  line: 7
   column: 16
   text: "\n  Welcome, "
 - name: content
-  line: 6
+  line: 8
   column: 15
   text: " admin_name "
 - name: content
-  line: 6
+  line: 8
   column: 29
   text: "\n"
 - name: content
-  line: 7
+  line: 9
   column: 3
   text: " end "
 - name: content
-  line: 7
+  line: 9
   column: 10
   text: "\n"


### PR DESCRIPTION
This pull request adds highlighting for Strict Locals in HTML+ERB files:

<img width="3696" height="1450" alt="CleanShot 2026-08-09 at 20 02 10@2x" src="https://github.com/user-attachments/assets/a63930d8-b240-4b2e-a401-7842d0aad5eb" />
