### PR TITLE
Attach Ruby LSP to Slim buffers

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -13,7 +13,7 @@ languages = ["Ruby"]
 
 [language_servers.ruby-lsp]
 name = "Ruby LSP"
-languages = ["Ruby", "ERB", "HTML+ERB", "YAML+ERB", "JS+ERB"]
+languages = ["Ruby", "ERB", "HTML+ERB", "YAML+ERB", "JS+ERB", "Slim"]
 
 [language_servers.ruby-lsp.language_ids]
 "Ruby" = "ruby"
@@ -21,6 +21,7 @@ languages = ["Ruby", "ERB", "HTML+ERB", "YAML+ERB", "JS+ERB"]
 "HTML+ERB" = "erb"
 "YAML+ERB" = "erb"
 "JS+ERB" = "erb"
+"Slim" = "slim"
 
 [language_servers.rubocop]
 name = "Rubocop"


### PR DESCRIPTION
## Summary

- Attach Ruby LSP to [Slim](https://slim-template.github.io) buffers
- Map Slim buffers to the `slim` LSP language identifier

This allows projects with the
[`ruby-lsp-slim`](https://github.com/afomera/ruby-lsp-slim) add-on installed
to use it in Zed. The extension does not install the add-on itself.

## Testing

- `cargo test`
- Loaded this checkout as a Zed development extension
- Opened a `.html.slim` file with `ruby-lsp-slim` 0.1.0 installed and
  confirmed: `[Ruby LSP Slim] Addon v0.1.0 activated`