### PR TITLE
test: Move `MockCommandExecutor` to a shared location

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -74,82 +74,9 @@ impl<E: CommandExecutor> Bundler<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_executor::CommandExecutor;
-    use std::cell::RefCell;
+    use crate::command_executor::MockCommandExecutor;
     use std::path::Path;
     use zed_extension_api::process::Output;
-
-    struct MockExecutorConfig {
-        output_to_return: Option<Result<Output, String>>,
-        expected_command_name: Option<String>,
-        expected_args: Option<Vec<String>>,
-        expected_envs: Option<Vec<(String, String)>>,
-    }
-
-    struct MockCommandExecutor {
-        config: RefCell<MockExecutorConfig>,
-    }
-
-    impl MockCommandExecutor {
-        fn new() -> Self {
-            MockCommandExecutor {
-                config: RefCell::new(MockExecutorConfig {
-                    output_to_return: None,
-                    expected_command_name: None,
-                    expected_args: None,
-                    expected_envs: None,
-                }),
-            }
-        }
-
-        fn expect(
-            &self,
-            command_name: &str,
-            full_args: &[&str],
-            final_envs: &[(&str, &str)],
-            output: Result<Output, String>,
-        ) {
-            let mut config = self.config.borrow_mut();
-            config.expected_command_name = Some(command_name.to_string());
-            config.expected_args = Some(full_args.iter().map(|s| s.to_string()).collect());
-            config.expected_envs = Some(
-                final_envs
-                    .iter()
-                    .map(|&(k, v)| (k.to_string(), v.to_string()))
-                    .collect(),
-            );
-            config.output_to_return = Some(output);
-        }
-    }
-
-    impl CommandExecutor for MockCommandExecutor {
-        fn execute(
-            &self,
-            command_name: &str,
-            args: &[&str],
-            envs: &[(&str, &str)],
-        ) -> Result<Output, String> {
-            let mut config = self.config.borrow_mut();
-
-            if let Some(expected_name) = &config.expected_command_name {
-                assert_eq!(command_name, expected_name, "Mock: Command name mismatch");
-            }
-            if let Some(expected_args) = &config.expected_args {
-                assert_eq!(&args.to_vec(), expected_args, "Mock: Args mismatch");
-            }
-            if let Some(expected_envs) = &config.expected_envs {
-                let envs: Vec<(String, String)> = envs
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                assert_eq!(&envs, expected_envs, "Mock: Env mismatch");
-            }
-
-            config.output_to_return.take().expect(
-                "MockCommandExecutor: output_to_return was not set or already consumed for the test",
-            )
-        }
-    }
 
     fn create_mock_executor_for_success(
         version: &str,

--- a/src/command_executor.rs
+++ b/src/command_executor.rs
@@ -42,3 +42,85 @@ impl CommandExecutor for RealCommandExecutor {
             .output()
     }
 }
+
+#[cfg(test)]
+pub struct MockCommandExecutor {
+    config: std::cell::RefCell<MockExecutorConfig>,
+}
+
+#[cfg(test)]
+struct MockExecutorConfig {
+    output_to_return: Option<zed::Result<zed::process::Output>>,
+    expected_command_name: Option<String>,
+    expected_args: Option<Vec<String>>,
+    expected_envs: Option<Vec<(String, String)>>,
+}
+
+#[cfg(test)]
+impl MockCommandExecutor {
+    pub fn new() -> Self {
+        Self {
+            config: std::cell::RefCell::new(MockExecutorConfig {
+                output_to_return: None,
+                expected_command_name: None,
+                expected_args: None,
+                expected_envs: None,
+            }),
+        }
+    }
+
+    pub fn expect(
+        &self,
+        command_name: &str,
+        args: &[&str],
+        envs: &[(&str, &str)],
+        output: zed::Result<zed::process::Output>,
+    ) {
+        let mut config = self.config.borrow_mut();
+        config.expected_command_name = Some(command_name.to_string());
+        config.expected_args = Some(args.iter().map(ToString::to_string).collect());
+        config.expected_envs = Some(
+            envs.iter()
+                .map(|&(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        );
+        config.output_to_return = Some(output);
+    }
+}
+
+#[cfg(test)]
+impl CommandExecutor for MockCommandExecutor {
+    fn execute(
+        &self,
+        command_name: &str,
+        args: &[&str],
+        envs: &[(&str, &str)],
+    ) -> zed::Result<zed::process::Output> {
+        let mut config = self.config.borrow_mut();
+
+        if let Some(expected) = &config.expected_command_name {
+            assert_eq!(command_name, expected, "Mock: command name mismatch");
+        }
+        if let Some(expected) = &config.expected_args {
+            assert_eq!(
+                args.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                *expected,
+                "Mock: args mismatch"
+            );
+        }
+        if let Some(expected) = &config.expected_envs {
+            assert_eq!(
+                envs.iter()
+                    .map(|&(key, value)| (key.to_string(), value.to_string()))
+                    .collect::<Vec<_>>(),
+                *expected,
+                "Mock: env mismatch"
+            );
+        }
+
+        config
+            .output_to_return
+            .take()
+            .expect("MockCommandExecutor: output was not set or was already consumed")
+    }
+}

--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -201,83 +201,9 @@ impl Gemset {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::command_executor::CommandExecutor;
-    use std::cell::RefCell;
+    use crate::command_executor::MockCommandExecutor;
     use std::path::Path;
     use zed_extension_api::process::Output;
-
-    struct MockExecutorConfig {
-        expected_command_name: Option<String>,
-        expected_args: Option<Vec<String>>,
-        expected_envs: Option<Vec<(String, String)>>,
-        output_to_return: Option<Result<Output, String>>,
-    }
-
-    struct MockCommandExecutor {
-        config: RefCell<MockExecutorConfig>,
-    }
-
-    impl MockCommandExecutor {
-        fn new() -> Self {
-            MockCommandExecutor {
-                config: RefCell::new(MockExecutorConfig {
-                    expected_command_name: None,
-                    expected_args: None,
-                    expected_envs: None,
-                    output_to_return: None,
-                }),
-            }
-        }
-
-        fn expect(
-            &self,
-            command_name: &str,
-            full_args: &[&str],
-            final_envs: &[(&str, &str)],
-            output: Result<Output, String>,
-        ) {
-            let mut config = self.config.borrow_mut();
-            config.expected_command_name = Some(command_name.to_string());
-            config.expected_args = Some(full_args.iter().map(|s| s.to_string()).collect());
-            config.expected_envs = Some(
-                final_envs
-                    .iter()
-                    .map(|&(k, v)| (k.to_string(), v.to_string()))
-                    .collect(),
-            );
-            config.output_to_return = Some(output);
-        }
-    }
-
-    impl CommandExecutor for MockCommandExecutor {
-        fn execute(
-            &self,
-            command_name: &str,
-            args: &[&str],
-            envs: &[(&str, &str)],
-        ) -> Result<Output, String> {
-            let mut config = self.config.borrow_mut();
-
-            if let Some(expected_name) = &config.expected_command_name {
-                assert_eq!(command_name, expected_name, "Mock: Command name mismatch");
-            }
-            if let Some(expected_args) = &config.expected_args {
-                assert_eq!(&args, expected_args, "Mock: Args mismatch");
-            }
-            if let Some(expected_envs) = &config.expected_envs {
-                let envs: Vec<(String, String)> = envs
-                    .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                assert_eq!(&envs, expected_envs, "Mock: Env mismatch");
-            }
-
-            config
-                .output_to_return
-                .take()
-                .expect("MockCommandExecutor: output_to_return was not set or already consumed")
-        }
-    }
 
     const TEST_GEM_HOME: &str = "/test/gem_home";
     const TEST_GEM_PATH: &str = "/test/gem_path";


### PR DESCRIPTION
Move `MockCommandExecutor` to a shared location