### PR TITLE
fix(ruby): scope string overrides to literal content

### DIFF
--- a/languages/ruby/overrides.scm
+++ b/languages/ruby/overrides.scm
@@ -1,3 +1,4 @@
 (comment) @comment.inclusive
 
-(string) @string
+(string
+  (string_content) @string.inclusive)

--- a/tests/languages/ruby/overrides.rb
+++ b/tests/languages/ruby/overrides.rb
@@ -1,0 +1,6 @@
+# A Ruby comment
+plain_string = "plain text"
+interpolated_string = "hello #{user.name}"
+single_quoted_string = 'single quoted text'
+regexp = /[a-z]+/
+symbol = :valid?

--- a/tests/languages/ruby/snapshots/overrides.snap
+++ b/tests/languages/ruby/snapshots/overrides.snap
@@ -1,0 +1,20 @@
+---
+source: tests/support/mod.rs
+expression: captures
+---
+- name: comment.inclusive
+  line: 1
+  column: 1
+  text: "# A Ruby comment"
+- name: string.inclusive
+  line: 2
+  column: 17
+  text: plain text
+- name: string.inclusive
+  line: 3
+  column: 24
+  text: "hello "
+- name: string.inclusive
+  line: 4
+  column: 25
+  text: single quoted text

--- a/tests/ruby.rs
+++ b/tests/ruby.rs
@@ -64,3 +64,16 @@ fn injections() {
         "languages/ruby/injections.scm",
     );
 }
+
+// ============================================================================
+// Overrides Tests
+// ============================================================================
+
+#[test]
+fn overrides() {
+    support::assert_query_snapshot(
+        "overrides",
+        "tests/languages/ruby/overrides.rb",
+        "languages/ruby/overrides.scm",
+    );
+}


### PR DESCRIPTION
The Ruby extension currently captures each entire string with:

```scheme
(string) @string
```

A Ruby string can contain executable Ruby code:

```ruby
"The result is #{user.name}"
```

The broad capture also applies the string scope to `user.name` inside the interpolation. This can enable string-specific settings in normal Ruby code.
Changing the query to:

```scheme
(string
  (string_content) @string.inclusive)
```
fixes the problem.

This limits the string scope to literal content:

```text
string
->string_content       -> string scope
->interpolation          -> normal Ruby scope
```

This keeps string-specific settings, including Tailwind language-server opt-in and completion query characters, inside Ruby string content. Ruby code inside `#{...}` keeps normal Ruby behavior.

Closes https://github.com/zed-extensions/ruby/issues/313