### PR TITLE
fix(gemset): stop calling std::env::split_paths on wasm

### DIFF
--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -82,10 +82,12 @@ impl Gemset {
             env_map
                 .entry("GEM_PATH".to_string())
                 .and_modify(|existing_gem_path| {
-                    let paths: Vec<_> = std::env::split_paths(existing_gem_path).collect();
-                    let gem_home_path = std::path::Path::new(&gem_path);
+                    let gem_home_path = Path::new(&gem_path);
+                    let already_listed = existing_gem_path
+                        .split(':')
+                        .any(|entry| Path::new(entry) == gem_home_path);
 
-                    if !paths.iter().any(|p| p == gem_home_path) {
+                    if !already_listed {
                         *existing_gem_path = format!("{gem_path}:{existing_gem_path}");
                     }
                 })
@@ -379,6 +381,31 @@ mod tests {
             &format!("{gem_home}:{TEST_GEM_PATH}")
         );
         assert_eq!(env.get("PATH").unwrap(), &format!("/usr/bin:{gem_bin}"));
+    }
+
+    #[test]
+    fn test_gem_env_does_not_duplicate_gem_home_in_gem_path() {
+        let existing = format!("{TEST_GEM_PATH}:{TEST_GEM_HOME}");
+        let gemset = Gemset::new(
+            TEST_GEM_HOME.into(),
+            Some(&[("GEM_PATH", &existing)]),
+            Box::new(MockCommandExecutor::new()),
+        );
+        let env: std::collections::HashMap<String, String> = gemset.env().iter().cloned().collect();
+
+        assert_eq!(env.get("GEM_PATH").unwrap(), &existing);
+    }
+
+    #[test]
+    fn test_gem_env_without_gem_path() {
+        let gemset = Gemset::new(
+            TEST_GEM_HOME.into(),
+            Some(&[("PATH", "/usr/bin")]),
+            Box::new(MockCommandExecutor::new()),
+        );
+        let env: std::collections::HashMap<String, String> = gemset.env().iter().cloned().collect();
+
+        assert_eq!(env.get("GEM_PATH").unwrap(), TEST_GEM_HOME);
     }
 
     #[test]

--- a/src/gemset.rs
+++ b/src/gemset.rs
@@ -7,6 +7,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{LazyLock, OnceLock},
 };
+use zed_extension_api::Os;
 
 pub fn versioned_gem_home(
     base_dir: &Path,
@@ -34,19 +35,30 @@ pub fn versioned_gem_home(
 /// A simple wrapper around the `gem` command.
 pub struct Gemset {
     gem_home: PathBuf,
+    path_separator: char,
     envs: Vec<(String, String)>,
     cached_env: OnceLock<Vec<(String, String)>>,
     command_executor: Box<dyn CommandExecutor>,
 }
 
+fn path_list_separator(os: Os) -> char {
+    if matches!(os, Os::Windows) {
+        ';'
+    } else {
+        ':'
+    }
+}
+
 impl Gemset {
     pub fn new(
         gem_home: PathBuf,
+        os: Os,
         envs: Option<&[(&str, &str)]>,
         command_executor: Box<dyn CommandExecutor>,
     ) -> Self {
         Self {
             gem_home,
+            path_separator: path_list_separator(os),
             envs: envs.map_or(Vec::new(), |envs| {
                 envs.iter()
                     .map(|&(k, v)| (k.to_string(), v.to_string()))
@@ -75,6 +87,7 @@ impl Gemset {
                 .collect();
 
             let gem_path = self.gem_home.display().to_string();
+            let separator = self.path_separator;
 
             // If the GEM_PATH env variable is already set,
             // prepend our gem home directory to it to ensure
@@ -84,11 +97,11 @@ impl Gemset {
                 .and_modify(|existing_gem_path| {
                     let gem_home_path = Path::new(&gem_path);
                     let already_listed = existing_gem_path
-                        .split(':')
+                        .split(separator)
                         .any(|entry| Path::new(entry) == gem_home_path);
 
                     if !already_listed {
-                        *existing_gem_path = format!("{gem_path}:{existing_gem_path}");
+                        *existing_gem_path = format!("{gem_path}{separator}{existing_gem_path}");
                     }
                 })
                 .or_insert(gem_path);
@@ -97,7 +110,7 @@ impl Gemset {
             env_map
                 .entry("PATH".to_string())
                 .and_modify(|path| {
-                    *path = format!("{}:{}", path, self.gem_home.join("bin").display())
+                    *path = format!("{path}{separator}{}", self.gem_home.join("bin").display())
                 })
                 .or_insert(self.gem_home.join("bin").display().to_string());
 
@@ -211,7 +224,12 @@ mod tests {
     const TEST_GEM_PATH: &str = "/test/gem_path";
 
     fn create_gemset(envs: Option<&[(&str, &str)]>, mock_executor: MockCommandExecutor) -> Gemset {
-        Gemset::new(TEST_GEM_HOME.into(), envs, Box::new(mock_executor))
+        Gemset::new(
+            TEST_GEM_HOME.into(),
+            Os::Linux,
+            envs,
+            Box::new(mock_executor),
+        )
     }
 
     #[test]
@@ -351,6 +369,7 @@ mod tests {
     fn test_gem_bin_path() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
+            Os::Linux,
             None,
             Box::new(MockCommandExecutor::new()),
         );
@@ -367,6 +386,7 @@ mod tests {
     fn test_gem_env() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
+            Os::Linux,
             Some(&[("GEM_PATH", TEST_GEM_PATH), ("PATH", "/usr/bin")]),
             Box::new(MockCommandExecutor::new()),
         );
@@ -388,6 +408,7 @@ mod tests {
         let existing = format!("{TEST_GEM_PATH}:{TEST_GEM_HOME}");
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
+            Os::Linux,
             Some(&[("GEM_PATH", &existing)]),
             Box::new(MockCommandExecutor::new()),
         );
@@ -400,12 +421,55 @@ mod tests {
     fn test_gem_env_without_gem_path() {
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
+            Os::Linux,
             Some(&[("PATH", "/usr/bin")]),
             Box::new(MockCommandExecutor::new()),
         );
         let env: std::collections::HashMap<String, String> = gemset.env().iter().cloned().collect();
 
         assert_eq!(env.get("GEM_PATH").unwrap(), TEST_GEM_HOME);
+    }
+
+    #[test]
+    fn test_gem_env_on_windows() {
+        let gem_home = "C:/zed/gems/abc";
+        let gemset = Gemset::new(
+            gem_home.into(),
+            Os::Windows,
+            Some(&[
+                ("GEM_PATH", "C:/Ruby34/lib/ruby/gems/3.4.0;C:/Users/x/.gem"),
+                ("PATH", "C:/Windows/System32"),
+            ]),
+            Box::new(MockCommandExecutor::new()),
+        );
+        let env: std::collections::HashMap<String, String> = gemset.env().iter().cloned().collect();
+
+        assert_eq!(
+            env.get("GEM_PATH").unwrap(),
+            "C:/zed/gems/abc;C:/Ruby34/lib/ruby/gems/3.4.0;C:/Users/x/.gem"
+        );
+        assert_eq!(
+            env.get("PATH").unwrap(),
+            &format!(
+                "C:/Windows/System32;{}",
+                Path::new(gem_home).join("bin").display()
+            )
+        );
+    }
+
+    #[test]
+    fn test_gem_env_on_windows_does_not_duplicate_gem_home_in_gem_path() {
+        let gem_home = "C:/zed/gems/abc";
+        let existing = format!("C:/Ruby34/lib/ruby/gems/3.4.0;{gem_home}");
+        let gemset = Gemset::new(
+            gem_home.into(),
+            Os::Windows,
+            Some(&[("GEM_PATH", &existing)]),
+            Box::new(MockCommandExecutor::new()),
+        );
+        let env: std::collections::HashMap<String, String> = gemset.env().iter().cloned().collect();
+
+        assert_eq!(env.get("GEM_PATH").unwrap(), &existing);
     }
 
     #[test]
@@ -456,6 +520,7 @@ mod tests {
         );
         let gemset = Gemset::new(
             TEST_GEM_HOME.into(),
+            Os::Linux,
             Some(&[("CUSTOM_VAR", "custom_value")]),
             Box::new(mock_executor),
         );

--- a/src/language_servers/language_server.rs
+++ b/src/language_servers/language_server.rs
@@ -255,6 +255,7 @@ pub trait LanguageServer {
 
         let gemset = Gemset::new(
             gem_home,
+            zed::current_platform().0,
             Some(&worktree_shell_env_vars),
             Box::new(RealCommandExecutor),
         );

--- a/src/ruby.rs
+++ b/src/ruby.rs
@@ -162,7 +162,12 @@ impl zed::Extension for RubyExtension {
                     .map_err(|e| format!("Failed to get extension directory: {e:#}"))?;
                 let gem_home = versioned_gem_home(&base_dir, &env_vars, &RealCommandExecutor)
                     .map_err(|e| format!("{:#}", e))?;
-                let gemset = Gemset::new(gem_home, Some(&env_vars), Box::new(RealCommandExecutor));
+                let gemset = Gemset::new(
+                    gem_home,
+                    zed::current_platform().0,
+                    Some(&env_vars),
+                    Box::new(RealCommandExecutor),
+                );
                 gemset
                     .install_gem("debug")
                     .map_err(|e| format!("Failed to install debug gem: {e:#}"))?;


### PR DESCRIPTION
`Gemset::env` calls `std::env::split_paths` when `GEM_PATH` is set in the worktree shell environment. On `wasm32-wasip2` that function is `panic!("unsupported")`, so the extension aborts inside `language_server_command`:

```
Failed to start language server "solargraph": error while executing at wasm backtrace:
   11: zed_ruby.wasm!std::sys::pal::wasip2::os::split_paths
   12: zed_ruby.wasm!std::sys::sync::once::no_threads::Once::call
   13: zed_ruby.wasm!std::sync::once_lock::OnceLock<T>::initialize
   14: zed_ruby.wasm!zed_ruby::language_servers::language_server::LanguageServer::try_find_on_path_or_extension_gemset
   15: zed_ruby.wasm!zed_ruby::language_servers::language_server::LanguageServer::language_server_command
Caused by:
    wasm trap: wasm `unreachable` instruction executed
```

After the trap wasmtime refuses every further call into the extension with `wasm trap: cannot enter component instance`, so all Ruby language servers stay down until Zed restarts. Introduced in #189.

Two commits:

1. Split `GEM_PATH` with a plain string split instead of `std::env::split_paths`.
2. Take the host OS from `zed::current_platform()` and use `;` on Windows for the split and for both joins. The joins were hard-coded to `:` before, which produced values Ruby cannot read on Windows.

Tests cover gem home already present in `GEM_PATH`, `GEM_PATH` absent, and both cases on Windows.

Verified with `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo build --target wasm32-wasip2`.
